### PR TITLE
feat(session): enable prompt caching via stream options

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -5,6 +5,7 @@ import {
 	type Context,
 	type Message,
 	type Model,
+	type ProviderStreamOptions,
 	stream,
 	type Tool,
 } from "@mariozechner/pi-ai";
@@ -181,6 +182,8 @@ export interface SessionConfig {
 	stream?: typeof stream;
 	/** Context compaction settings (defaults to sensible values) */
 	compaction?: Partial<CompactionSettings>;
+	/** Stream options passed to pi-ai's stream function (e.g., cacheRetention for prompt caching) */
+	streamOptions?: ProviderStreamOptions;
 }
 
 /**
@@ -219,7 +222,14 @@ export class Session {
 		this.repo = repo;
 		this.#config = config;
 		this.#logger = config.logger ?? consoleLogger;
-		this.#stream = config.stream ?? stream;
+
+		const baseStream = config.stream ?? stream;
+		const streamOptions: ProviderStreamOptions = {
+			sessionId: this.id,
+			...config.streamOptions,
+		};
+		this.#stream = (model, context) => baseStream(model, context, streamOptions);
+
 		this.#context = {
 			systemPrompt: config.systemPrompt,
 			messages: [],


### PR DESCRIPTION
## Summary

Pass `sessionId` to pi-ai's `stream()` function and expose `streamOptions` on `SessionConfig` for caller overrides.

## What this enables

pi-ai already defaults `cacheRetention` to `"short"`, which means the **system prompt** and **last user message** (conversation history prefix) are already cached by the Anthropic provider via `cache_control: {type: "ephemeral"}`. This was working before this PR.

What was **missing** is `sessionId`, which providers use as follows:
- **OpenAI Responses**: `prompt_cache_key` for session-pinned caching
- **Azure OpenAI**: `prompt_cache_key`
- **Codex**: WebSocket session routing + `prompt_cache_key`
- **Anthropic**: Not used (caching is marker-based, not session-based)

## Changes

### `src/session.ts`
- Add `streamOptions?: ProviderStreamOptions` to `SessionConfig`
- Bind `sessionId` (session UUID) and any caller-provided `streamOptions` into the stream function at construction time
- `processStream` remains unchanged — stream options are the Session's concern, not the stream processor's

### What is NOT cached

Tool definitions are **not** cached by pi-ai's Anthropic provider — `convertTools()` does not add `cache_control` markers. Caching tools would require changes upstream in pi-ai.

## Values of `cacheRetention`

| Value | Effect (Anthropic) | Effect (OpenAI Responses) |
|-------|-------------------|--------------------------|
| `"none"` | No cache markers | No `prompt_cache_key`/`prompt_cache_retention` |
| `"short"` (default) | `{type: "ephemeral"}` on system prompt + last user msg | `prompt_cache_key` from sessionId |
| `"long"` | `{type: "ephemeral", ttl: "1h"}` (direct API only) | `prompt_cache_retention: "auto"` |