### PR TITLE
Await on worktree cleanup to prevent race condition

### DIFF
--- a/scripts/eval/run-eval.ts
+++ b/scripts/eval/run-eval.ts
@@ -212,7 +212,7 @@ async function runEval(inputPath: string): Promise<void> {
 				judge_prompt: judgePromptText,
 			});
 		} finally {
-			session?.close();
+			await session?.close();
 		}
 	}
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -279,16 +279,15 @@ export class Session {
 	 * The session cannot be used after closing.
 	 * Safe to call multiple times.
 	 */
-	close(): void {
+	async close(): Promise<void> {
 		if (this.#closed) return;
 		this.#closed = true;
 
-		// Clean up worktree asynchronously, log if it fails
-		cleanupWorktree(this.repo).then((success) => {
-			if (!success) {
-				this.#logger.error("Failed to cleanup worktree", { path: this.repo.localPath });
-			}
-		});
+		// Clean up worktree, log if it fails
+		const success = await cleanupWorktree(this.repo);
+		if (!success) {
+			this.#logger.error("Failed to cleanup worktree", { path: this.repo.localPath });
+		}
 	}
 
 	async #doAsk(question: string, onProgress?: OnProgress): Promise<AskResult> {


### PR DESCRIPTION
Between 2 consecutive iterations, if the first iteration's worktree cleanup step hasn't completed and the next iteration uses the same worktree (see usage of exists(worktreePath) in src/forge.ts), the second iteration ends up referring the deleted worktree causing it to fail