### PR TITLE
feat: add configurable adaptive thinking support (off by default)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
 		"lint": "biome lint .",
 		"check": "biome check --write .",
 		"test": "bun test",
-		"web": "bun run web/server.ts"
+		"web": "bun run web/server.ts",
+		"postinstall": "patch -p0 -N -d node_modules/@mariozechner/pi-ai < patches/pi-ai-output-config.patch || true"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.3.11",

--- a/scripts/eval/csv.ts
+++ b/scripts/eval/csv.ts
@@ -28,6 +28,7 @@ export interface EvalRow {
 	judge_model: string;
 	ask_system_prompt: string;
 	judge_prompt: string;
+	reasoning_level: string;
 }
 
 // =============================================================================

--- a/scripts/eval/csv.ts
+++ b/scripts/eval/csv.ts
@@ -61,6 +61,7 @@ const OUTPUT_COLUMNS = [
 	"judge_model",
 	"ask_system_prompt",
 	"judge_prompt",
+	"reasoning_level",
 ] as const;
 
 // =============================================================================

--- a/scripts/eval/eval-viewer.html
+++ b/scripts/eval/eval-viewer.html
@@ -1047,7 +1047,7 @@
  *   inferenceTimeMs: string,
  * }} EvalRow
  *
- * @typedef {{ rows: EvalRow[], name: string, askModel: string, judgeModel: string }} EvalRun
+ * @typedef {{ rows: EvalRow[], name: string, askModel: string, judgeModel: string, reasoningLevel: string }} EvalRun
  *
  * @typedef {{
  *   key: string,
@@ -1201,8 +1201,9 @@ function parseCsv(content, fileName) {
   // so we treat the first row's values as canonical for the whole run.
   const askModel = rows.length > 0 ? (rows[0].askModel || '') : '';
   const judgeModel = rows.length > 0 ? (rows[0].judgeModel || '') : '';
+  const reasoningLevel = rows.length > 0 ? (rows[0].reasoningLevel || '') : '';
 
-  return { ok: true, run: { rows, name: fileName, askModel, judgeModel } };
+  return { ok: true, run: { rows, name: fileName, askModel, judgeModel, reasoningLevel } };
 }
 
 // ─── Row Matching & Comparison ───────────────────────────────────────────

--- a/scripts/eval/eval-viewer.html
+++ b/scripts/eval/eval-viewer.html
@@ -329,6 +329,14 @@
     color: var(--indigo-600);
     margin-right: 2px;
   }
+  .reasoning-chip {
+    background: var(--amber-50, #fffbeb);
+    color: var(--amber-700, #b45309);
+    border-color: var(--amber-100, #fef3c7);
+  }
+  .reasoning-chip .model-chip-label {
+    color: var(--amber-600, #d97706);
+  }
 
   /* ─── Summary Stats ─── */
   .stats-bar {
@@ -1138,6 +1146,7 @@ const COLUMN_ALIASES = {
   cache_write_tokens: 'cacheWriteTokens',
   ask_system_prompt: 'askSystemPrompt',
   judge_prompt: 'judgePrompt',
+  reasoning_level: 'reasoningLevel',
 };
 
 function makeEmptyRow() {
@@ -1151,6 +1160,7 @@ function makeEmptyRow() {
     cacheReadTokens: '', cacheWriteTokens: '',
     askModel: '', judgeModel: '',
     askSystemPrompt: '', judgePrompt: '',
+    reasoningLevel: '',
   };
 }
 
@@ -1566,6 +1576,8 @@ function renderModelChips(row) {
   let html = '<div class="model-bar">';
   if (askModel) html += `<span class="model-chip"><span class="model-chip-label">Ask</span>${esc(askModel)}</span>`;
   if (judgeModel) html += `<span class="model-chip"><span class="model-chip-label">Judge</span>${esc(judgeModel)}</span>`;
+  const reasoning = row.reasoningLevel?.trim() || '';
+  if (reasoning) html += `<span class="model-chip reasoning-chip"><span class="model-chip-label">Reasoning</span>${esc(reasoning)}</span>`;
   html += '</div>';
   return html;
 }

--- a/scripts/eval/run-eval.ts
+++ b/scripts/eval/run-eval.ts
@@ -1,7 +1,7 @@
 import "dotenv/config";
 import { mkdir, writeFile } from "node:fs/promises";
 import { completeSimple, getModel } from "@mariozechner/pi-ai";
-import { MAX_TOOL_ITERATIONS, MODEL_NAME, MODEL_PROVIDER } from "../../src/config";
+import { MAX_TOOL_ITERATIONS, MODEL_NAME, MODEL_PROVIDER, type ThinkingConfig } from "../../src/config";
 import { AskForgeClient, buildDefaultSystemPrompt, nullLogger } from "../../src/index";
 import { JUDGE_SYSTEM_PROMPT } from "../../src/prompt";
 import { type EvalRow, loadRowsFromCsv, writeCsvString } from "./csv";
@@ -77,7 +77,7 @@ ${answer}`;
 // Main
 // =============================================================================
 
-async function runEval(inputPath: string): Promise<void> {
+async function runEval(inputPath: string, thinking: ThinkingConfig | undefined): Promise<void> {
 	const timestamp = new Date().toISOString().replace(/[:.]/g, "-").replace("T", "_").replace("Z", "");
 	const reportsDir = new URL("reports/", import.meta.url).pathname;
 	await mkdir(reportsDir, { recursive: true });
@@ -92,13 +92,18 @@ async function runEval(inputPath: string): Promise<void> {
 	}
 
 	console.log(`Reading dataset from: ${inputPath}`);
-	console.log(`Found ${rows.length} rows to evaluate\n`);
+	console.log(`Found ${rows.length} rows to evaluate`);
+	if (thinking) {
+		console.log(`Adaptive thinking: enabled (effort: ${thinking.effort ?? "default"})`);
+	}
+	console.log();
 
 	const client = new AskForgeClient(
 		{
 			provider: MODEL_PROVIDER,
 			model: MODEL_NAME,
 			maxIterations: MAX_TOOL_ITERATIONS,
+			thinking,
 		},
 		nullLogger,
 	);
@@ -233,10 +238,16 @@ async function runEval(inputPath: string): Promise<void> {
 }
 
 // CLI entry point
-const inputPath = process.argv[2];
+const args = process.argv.slice(2);
+const thinkingFlag = args.includes("--thinking");
+const positionalArgs = args.filter((a) => !a.startsWith("--"));
+const inputPath = positionalArgs[0];
+
 if (!inputPath) {
-	console.error("Usage: bun run eval/run-eval.ts <path-to-dataset.csv>");
+	console.error("Usage: bun run eval/run-eval.ts <path-to-dataset.csv> [--thinking]");
 	process.exit(1);
 }
 
-await runEval(inputPath);
+const thinkingConfig: ThinkingConfig | undefined = thinkingFlag ? { mode: "adaptive" } : undefined;
+
+await runEval(inputPath, thinkingConfig);

--- a/scripts/eval/run-eval.ts
+++ b/scripts/eval/run-eval.ts
@@ -1,5 +1,6 @@
 import "dotenv/config";
 import { mkdir, writeFile } from "node:fs/promises";
+import { parseArgs } from "node:util";
 import { completeSimple, getModel, type ThinkingLevel } from "@mariozechner/pi-ai";
 import { MAX_TOOL_ITERATIONS, MODEL_NAME, MODEL_PROVIDER, type ThinkingConfig } from "../../src/config";
 import { AskForgeClient, buildDefaultSystemPrompt, nullLogger } from "../../src/index";
@@ -241,22 +242,28 @@ async function runEval(inputPath: string, thinking: ThinkingConfig | undefined):
 
 // CLI entry point
 const VALID_LEVELS = new Set<string>(["minimal", "low", "medium", "high", "xhigh", "adaptive"]);
-const args = process.argv.slice(2);
-const thinkingArg = args.find((a) => a.startsWith("--thinking"));
-const positionalArgs = args.filter((a) => !a.startsWith("--"));
-const inputPath = positionalArgs[0];
+
+const { values, positionals } = parseArgs({
+	args: Bun.argv,
+	options: {
+		thinking: { type: "string", default: "" },
+	},
+	strict: true,
+	allowPositionals: true,
+});
+
+const inputPath = positionals[2]; // skip bun executable and script path
 
 if (!inputPath) {
-	console.error("Usage: bun run eval/run-eval.ts <path-to-dataset.csv> [--thinking[=<level>]]");
-	console.error("  --thinking           adaptive (model decides effort, Anthropic-only)");
-	console.error("  --thinking=<level>   minimal, low, medium, high, xhigh, adaptive");
+	console.error("Usage: bun run eval/run-eval.ts <path-to-dataset.csv> [--thinking <level>]");
+	console.error("  --thinking adaptive   model decides effort (Anthropic-only)");
+	console.error("  --thinking <level>    minimal, low, medium, high, xhigh, adaptive");
 	process.exit(1);
 }
 
 let thinking: ThinkingConfig | undefined;
-if (thinkingArg) {
-	const value = thinkingArg.includes("=") ? thinkingArg.split("=")[1] : undefined;
-	const level = value ?? "adaptive";
+if (values.thinking) {
+	const level = values.thinking;
 	if (!VALID_LEVELS.has(level)) {
 		console.error(`Invalid level: "${level}". Must be one of: ${[...VALID_LEVELS].join(", ")}`);
 		process.exit(1);

--- a/scripts/eval/run-eval.ts
+++ b/scripts/eval/run-eval.ts
@@ -1,8 +1,7 @@
 import "dotenv/config";
 import { mkdir, writeFile } from "node:fs/promises";
-import type { ThinkingLevel } from "@mariozechner/pi-ai";
-import { completeSimple, getModel } from "@mariozechner/pi-ai";
-import { MAX_TOOL_ITERATIONS, MODEL_NAME, MODEL_PROVIDER } from "../../src/config";
+import { completeSimple, getModel, type ThinkingLevel } from "@mariozechner/pi-ai";
+import { MAX_TOOL_ITERATIONS, MODEL_NAME, MODEL_PROVIDER, type ThinkingConfig } from "../../src/config";
 import { AskForgeClient, buildDefaultSystemPrompt, nullLogger } from "../../src/index";
 import { JUDGE_SYSTEM_PROMPT } from "../../src/prompt";
 import { type EvalRow, loadRowsFromCsv, writeCsvString } from "./csv";
@@ -78,7 +77,7 @@ ${answer}`;
 // Main
 // =============================================================================
 
-async function runEval(inputPath: string, reasoning: ThinkingLevel | undefined): Promise<void> {
+async function runEval(inputPath: string, thinking: ThinkingConfig | undefined): Promise<void> {
 	const timestamp = new Date().toISOString().replace(/[:.]/g, "-").replace("T", "_").replace("Z", "");
 	const reportsDir = new URL("reports/", import.meta.url).pathname;
 	await mkdir(reportsDir, { recursive: true });
@@ -94,8 +93,8 @@ async function runEval(inputPath: string, reasoning: ThinkingLevel | undefined):
 
 	console.log(`Reading dataset from: ${inputPath}`);
 	console.log(`Found ${rows.length} rows to evaluate`);
-	if (reasoning) {
-		console.log(`Reasoning level: ${reasoning}`);
+	if (thinking) {
+		console.log(`Thinking: ${thinking.level}`);
 	}
 	console.log();
 
@@ -104,7 +103,7 @@ async function runEval(inputPath: string, reasoning: ThinkingLevel | undefined):
 			provider: MODEL_PROVIDER,
 			model: MODEL_NAME,
 			maxIterations: MAX_TOOL_ITERATIONS,
-			reasoning,
+			thinking,
 		},
 		nullLogger,
 	);
@@ -192,7 +191,7 @@ async function runEval(inputPath: string, reasoning: ThinkingLevel | undefined):
 				judge_model: judgeModelLabel,
 				ask_system_prompt: askSystemPrompt,
 				judge_prompt: judgePromptText,
-				reasoning_level: reasoning ?? "",
+				reasoning_level: askResult.responseEffort ?? "",
 			});
 		} catch (error) {
 			console.error(`  ✗ Error: ${error instanceof Error ? error.message : String(error)}`);
@@ -217,7 +216,7 @@ async function runEval(inputPath: string, reasoning: ThinkingLevel | undefined):
 				judge_model: judgeModelLabel,
 				ask_system_prompt: askSystemPrompt,
 				judge_prompt: judgePromptText,
-				reasoning_level: reasoning ?? "",
+				reasoning_level: "",
 			});
 		} finally {
 			await session?.close();
@@ -241,16 +240,28 @@ async function runEval(inputPath: string, reasoning: ThinkingLevel | undefined):
 }
 
 // CLI entry point
+const VALID_LEVELS = new Set<string>(["minimal", "low", "medium", "high", "xhigh", "adaptive"]);
 const args = process.argv.slice(2);
-const reasoningFlag = args.includes("--reasoning");
+const thinkingArg = args.find((a) => a.startsWith("--thinking"));
 const positionalArgs = args.filter((a) => !a.startsWith("--"));
 const inputPath = positionalArgs[0];
 
 if (!inputPath) {
-	console.error("Usage: bun run eval/run-eval.ts <path-to-dataset.csv> [--reasoning]");
+	console.error("Usage: bun run eval/run-eval.ts <path-to-dataset.csv> [--thinking[=<level>]]");
+	console.error("  --thinking           adaptive (model decides effort, Anthropic-only)");
+	console.error("  --thinking=<level>   minimal, low, medium, high, xhigh, adaptive");
 	process.exit(1);
 }
 
-const reasoning: ThinkingLevel | undefined = reasoningFlag ? "high" : undefined;
+let thinking: ThinkingConfig | undefined;
+if (thinkingArg) {
+	const value = thinkingArg.includes("=") ? thinkingArg.split("=")[1] : undefined;
+	const level = value ?? "adaptive";
+	if (!VALID_LEVELS.has(level)) {
+		console.error(`Invalid level: "${level}". Must be one of: ${[...VALID_LEVELS].join(", ")}`);
+		process.exit(1);
+	}
+	thinking = { level: level as ThinkingLevel | "adaptive" };
+}
 
-await runEval(inputPath, reasoning);
+await runEval(inputPath, thinking);

--- a/scripts/eval/run-eval.ts
+++ b/scripts/eval/run-eval.ts
@@ -192,6 +192,7 @@ async function runEval(inputPath: string, reasoning: ThinkingLevel | undefined):
 				judge_model: judgeModelLabel,
 				ask_system_prompt: askSystemPrompt,
 				judge_prompt: judgePromptText,
+				reasoning_level: reasoning ?? "",
 			});
 		} catch (error) {
 			console.error(`  ✗ Error: ${error instanceof Error ? error.message : String(error)}`);
@@ -216,6 +217,7 @@ async function runEval(inputPath: string, reasoning: ThinkingLevel | undefined):
 				judge_model: judgeModelLabel,
 				ask_system_prompt: askSystemPrompt,
 				judge_prompt: judgePromptText,
+				reasoning_level: reasoning ?? "",
 			});
 		} finally {
 			await session?.close();

--- a/scripts/eval/run-eval.ts
+++ b/scripts/eval/run-eval.ts
@@ -1,7 +1,8 @@
 import "dotenv/config";
 import { mkdir, writeFile } from "node:fs/promises";
+import type { ThinkingLevel } from "@mariozechner/pi-ai";
 import { completeSimple, getModel } from "@mariozechner/pi-ai";
-import { MAX_TOOL_ITERATIONS, MODEL_NAME, MODEL_PROVIDER, type ThinkingConfig } from "../../src/config";
+import { MAX_TOOL_ITERATIONS, MODEL_NAME, MODEL_PROVIDER } from "../../src/config";
 import { AskForgeClient, buildDefaultSystemPrompt, nullLogger } from "../../src/index";
 import { JUDGE_SYSTEM_PROMPT } from "../../src/prompt";
 import { type EvalRow, loadRowsFromCsv, writeCsvString } from "./csv";
@@ -77,7 +78,7 @@ ${answer}`;
 // Main
 // =============================================================================
 
-async function runEval(inputPath: string, thinking: ThinkingConfig | undefined): Promise<void> {
+async function runEval(inputPath: string, reasoning: ThinkingLevel | undefined): Promise<void> {
 	const timestamp = new Date().toISOString().replace(/[:.]/g, "-").replace("T", "_").replace("Z", "");
 	const reportsDir = new URL("reports/", import.meta.url).pathname;
 	await mkdir(reportsDir, { recursive: true });
@@ -93,8 +94,8 @@ async function runEval(inputPath: string, thinking: ThinkingConfig | undefined):
 
 	console.log(`Reading dataset from: ${inputPath}`);
 	console.log(`Found ${rows.length} rows to evaluate`);
-	if (thinking) {
-		console.log(`Adaptive thinking: enabled (effort: ${thinking.effort ?? "default"})`);
+	if (reasoning) {
+		console.log(`Reasoning level: ${reasoning}`);
 	}
 	console.log();
 
@@ -103,7 +104,7 @@ async function runEval(inputPath: string, thinking: ThinkingConfig | undefined):
 			provider: MODEL_PROVIDER,
 			model: MODEL_NAME,
 			maxIterations: MAX_TOOL_ITERATIONS,
-			thinking,
+			reasoning,
 		},
 		nullLogger,
 	);
@@ -239,15 +240,15 @@ async function runEval(inputPath: string, thinking: ThinkingConfig | undefined):
 
 // CLI entry point
 const args = process.argv.slice(2);
-const thinkingFlag = args.includes("--thinking");
+const reasoningFlag = args.includes("--reasoning");
 const positionalArgs = args.filter((a) => !a.startsWith("--"));
 const inputPath = positionalArgs[0];
 
 if (!inputPath) {
-	console.error("Usage: bun run eval/run-eval.ts <path-to-dataset.csv> [--thinking]");
+	console.error("Usage: bun run eval/run-eval.ts <path-to-dataset.csv> [--reasoning]");
 	process.exit(1);
 }
 
-const thinkingConfig: ThinkingConfig | undefined = thinkingFlag ? { mode: "adaptive" } : undefined;
+const reasoning: ThinkingLevel | undefined = reasoningFlag ? "high" : undefined;
 
-await runEval(inputPath, thinkingConfig);
+await runEval(inputPath, reasoning);

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,32 @@
  * This file contains all configurable settings for the TypeScript agent.
  */
 
+import type { ThinkingBudgets, ThinkingLevel } from "@mariozechner/pi-ai";
+
+// =============================================================================
+// THINKING CONFIGURATION
+// =============================================================================
+
+/**
+ * Configuration for reasoning/thinking.
+ *
+ * - ThinkingLevel ("minimal"|"low"|"medium"|"high"|"xhigh"): Works across all providers
+ *   via streamSimple(). Each provider translates to its native format.
+ * - "adaptive": Model decides effort per-request (Anthropic-only, uses stream() directly).
+ */
+export interface ThinkingConfig {
+	/**
+	 * Thinking level.
+	 * - ThinkingLevel: Works across all providers via streamSimple().
+	 * - "adaptive": Model decides effort per-request (Anthropic-only, uses stream() directly).
+	 */
+	level: ThinkingLevel | "adaptive";
+	/** Custom token budgets per level (for token-based providers like older Claude, Gemini). */
+	budgetOverrides?: ThinkingBudgets;
+}
+
+export type { ThinkingBudgets, ThinkingLevel };
+
 // =============================================================================
 // MODEL CONFIGURATION
 // =============================================================================

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,26 +5,6 @@
  */
 
 // =============================================================================
-// THINKING CONFIGURATION
-// =============================================================================
-
-/** Whether thinking is off or adaptive (model decides when/how much to think) */
-export type ThinkingMode = "off" | "adaptive";
-
-/**
- * Configuration for Claude's adaptive/extended thinking.
- * Default: thinking is off. Enable via `mode: "adaptive"` for eval-gated rollout.
- */
-export interface ThinkingConfig {
-	/** Thinking mode: "off" (default) or "adaptive" */
-	mode: ThinkingMode;
-	/** Effort level for adaptive thinking (Anthropic Opus 4.6+ only). Default: "high" */
-	effort?: "low" | "medium" | "high" | "max";
-	/** Explicit token budget for extended thinking (older Anthropic models). Ignored for adaptive. */
-	budgetTokens?: number;
-}
-
-// =============================================================================
 // MODEL CONFIGURATION
 // =============================================================================
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,6 +5,26 @@
  */
 
 // =============================================================================
+// THINKING CONFIGURATION
+// =============================================================================
+
+/** Whether thinking is off or adaptive (model decides when/how much to think) */
+export type ThinkingMode = "off" | "adaptive";
+
+/**
+ * Configuration for Claude's adaptive/extended thinking.
+ * Default: thinking is off. Enable via `mode: "adaptive"` for eval-gated rollout.
+ */
+export interface ThinkingConfig {
+	/** Thinking mode: "off" (default) or "adaptive" */
+	mode: ThinkingMode;
+	/** Effort level for adaptive thinking (Anthropic Opus 4.6+ only). Default: "high" */
+	effort?: "low" | "medium" | "high" | "max";
+	/** Explicit token budget for extended thinking (older Anthropic models). Ignored for adaptive. */
+	budgetTokens?: number;
+}
+
+// =============================================================================
 // MODEL CONFIGURATION
 // =============================================================================
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-import { getModel, type KnownProvider, type Message, streamSimple, type ThinkingLevel } from "@mariozechner/pi-ai";
-import { type CompactionSettings, MODEL_NAME, MODEL_PROVIDER } from "./config";
+import { getModel, type KnownProvider, type Message, stream, streamSimple } from "@mariozechner/pi-ai";
+import { type CompactionSettings, MODEL_NAME, MODEL_PROVIDER, type ThinkingConfig } from "./config";
 import { type ConnectOptions, connectRepo, type Forge, type ForgeName, type Repo } from "./forge";
 import { consoleLogger, type Logger, nullLogger } from "./logger";
 import { buildDefaultSystemPrompt } from "./prompt";
@@ -32,7 +32,7 @@ export type {
 	Repo,
 	SandboxClientConfig,
 	Session,
-	ThinkingLevel,
+	ThinkingConfig,
 	ToolCallRecord,
 };
 export { buildDefaultSystemPrompt, consoleLogger, nullLogger };
@@ -59,9 +59,8 @@ interface ForgeConfigBase {
 	 * Optional reasoning/thinking level.
 	 * Controls the model's thinking effort across providers (Anthropic, OpenAI, Google, etc.).
 	 * If omitted, thinking is off (default).
-	 * @see ThinkingLevel from pi-ai: "minimal" | "low" | "medium" | "high" | "xhigh"
 	 */
-	reasoning?: ThinkingLevel;
+	thinking?: ThinkingConfig;
 }
 
 /**
@@ -113,7 +112,7 @@ interface ResolvedConfig {
 	maxIterations: number;
 	sandbox?: SandboxClientConfig;
 	compaction?: Partial<CompactionSettings>;
-	reasoning?: ThinkingLevel;
+	thinking?: ThinkingConfig;
 }
 
 export class AskForgeClient {
@@ -137,7 +136,7 @@ export class AskForgeClient {
 			maxIterations: config.maxIterations ?? 20,
 			sandbox: config.sandbox,
 			compaction: config.compaction,
-			reasoning: config.reasoning,
+			thinking: config.thinking,
 		};
 		this.#logger = logger;
 
@@ -189,9 +188,10 @@ export class AskForgeClient {
 				maxIterations: config.maxIterations,
 				executeTool: sandboxExecuteTool,
 				logger: this.#logger,
-				stream: streamSimple,
+				stream,
+				streamSimple,
 				compaction: config.compaction,
-				reasoning: config.reasoning,
+				thinking: config.thinking,
 			});
 		}
 
@@ -207,9 +207,10 @@ export class AskForgeClient {
 			maxIterations: config.maxIterations,
 			executeTool,
 			logger: this.#logger,
-			stream: streamSimple,
+			stream,
+			streamSimple,
 			compaction: config.compaction,
-			reasoning: config.reasoning,
+			thinking: config.thinking,
 		});
 	}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { getModel, type KnownProvider, type Message, stream } from "@mariozechner/pi-ai";
-import { type CompactionSettings, MODEL_NAME, MODEL_PROVIDER } from "./config";
+import { type CompactionSettings, MODEL_NAME, MODEL_PROVIDER, type ThinkingConfig, type ThinkingMode } from "./config";
 import { type ConnectOptions, connectRepo, type Forge, type ForgeName, type Repo } from "./forge";
 import { consoleLogger, type Logger, nullLogger } from "./logger";
 import { buildDefaultSystemPrompt } from "./prompt";
@@ -32,6 +32,8 @@ export type {
 	Repo,
 	SandboxClientConfig,
 	Session,
+	ThinkingConfig,
+	ThinkingMode,
 	ToolCallRecord,
 };
 export { buildDefaultSystemPrompt, consoleLogger, nullLogger };
@@ -54,6 +56,12 @@ interface ForgeConfigBase {
 	 * If omitted, uses sensible defaults (enabled with 200K context window).
 	 */
 	compaction?: Partial<CompactionSettings>;
+	/**
+	 * Optional thinking configuration.
+	 * Controls whether the model uses adaptive/extended thinking.
+	 * If omitted, thinking is off (default).
+	 */
+	thinking?: ThinkingConfig;
 }
 
 /**
@@ -105,6 +113,7 @@ interface ResolvedConfig {
 	maxIterations: number;
 	sandbox?: SandboxClientConfig;
 	compaction?: Partial<CompactionSettings>;
+	thinking?: ThinkingConfig;
 }
 
 export class AskForgeClient {
@@ -128,6 +137,7 @@ export class AskForgeClient {
 			maxIterations: config.maxIterations ?? 20,
 			sandbox: config.sandbox,
 			compaction: config.compaction,
+			thinking: config.thinking,
 		};
 		this.#logger = logger;
 
@@ -181,6 +191,7 @@ export class AskForgeClient {
 				logger: this.#logger,
 				stream,
 				compaction: config.compaction,
+				thinking: config.thinking,
 			});
 		}
 
@@ -198,6 +209,7 @@ export class AskForgeClient {
 			logger: this.#logger,
 			stream,
 			compaction: config.compaction,
+			thinking: config.thinking,
 		});
 	}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-import { getModel, type KnownProvider, type Message, stream } from "@mariozechner/pi-ai";
-import { type CompactionSettings, MODEL_NAME, MODEL_PROVIDER, type ThinkingConfig, type ThinkingMode } from "./config";
+import { getModel, type KnownProvider, type Message, streamSimple, type ThinkingLevel } from "@mariozechner/pi-ai";
+import { type CompactionSettings, MODEL_NAME, MODEL_PROVIDER } from "./config";
 import { type ConnectOptions, connectRepo, type Forge, type ForgeName, type Repo } from "./forge";
 import { consoleLogger, type Logger, nullLogger } from "./logger";
 import { buildDefaultSystemPrompt } from "./prompt";
@@ -32,8 +32,7 @@ export type {
 	Repo,
 	SandboxClientConfig,
 	Session,
-	ThinkingConfig,
-	ThinkingMode,
+	ThinkingLevel,
 	ToolCallRecord,
 };
 export { buildDefaultSystemPrompt, consoleLogger, nullLogger };
@@ -57,11 +56,12 @@ interface ForgeConfigBase {
 	 */
 	compaction?: Partial<CompactionSettings>;
 	/**
-	 * Optional thinking configuration.
-	 * Controls whether the model uses adaptive/extended thinking.
+	 * Optional reasoning/thinking level.
+	 * Controls the model's thinking effort across providers (Anthropic, OpenAI, Google, etc.).
 	 * If omitted, thinking is off (default).
+	 * @see ThinkingLevel from pi-ai: "minimal" | "low" | "medium" | "high" | "xhigh"
 	 */
-	thinking?: ThinkingConfig;
+	reasoning?: ThinkingLevel;
 }
 
 /**
@@ -113,7 +113,7 @@ interface ResolvedConfig {
 	maxIterations: number;
 	sandbox?: SandboxClientConfig;
 	compaction?: Partial<CompactionSettings>;
-	thinking?: ThinkingConfig;
+	reasoning?: ThinkingLevel;
 }
 
 export class AskForgeClient {
@@ -137,7 +137,7 @@ export class AskForgeClient {
 			maxIterations: config.maxIterations ?? 20,
 			sandbox: config.sandbox,
 			compaction: config.compaction,
-			thinking: config.thinking,
+			reasoning: config.reasoning,
 		};
 		this.#logger = logger;
 
@@ -189,9 +189,9 @@ export class AskForgeClient {
 				maxIterations: config.maxIterations,
 				executeTool: sandboxExecuteTool,
 				logger: this.#logger,
-				stream,
+				stream: streamSimple,
 				compaction: config.compaction,
-				thinking: config.thinking,
+				reasoning: config.reasoning,
 			});
 		}
 
@@ -207,9 +207,9 @@ export class AskForgeClient {
 			maxIterations: config.maxIterations,
 			executeTool,
 			logger: this.#logger,
-			stream,
+			stream: streamSimple,
 			compaction: config.compaction,
-			thinking: config.thinking,
+			reasoning: config.reasoning,
 		});
 	}
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -5,10 +5,12 @@ import {
 	type Context,
 	type Message,
 	type Model,
+	type ProviderStreamOptions,
 	stream,
 	type Tool,
 } from "@mariozechner/pi-ai";
 import { type CompactionSettings, maybeCompact } from "./compaction";
+import type { ThinkingConfig } from "./config";
 import { cleanupWorktree, type Repo } from "./forge";
 import { consoleLogger, type Logger } from "./logger";
 import { type ParsedLink, validateLinks } from "./response-validation";
@@ -181,6 +183,8 @@ export interface SessionConfig {
 	stream?: typeof stream;
 	/** Context compaction settings (defaults to sensible values) */
 	compaction?: Partial<CompactionSettings>;
+	/** Thinking configuration (defaults to off) */
+	thinking?: ThinkingConfig;
 }
 
 /**
@@ -224,6 +228,18 @@ export class Session {
 			systemPrompt: config.systemPrompt,
 			messages: [],
 			tools: config.tools,
+		};
+	}
+
+	/** Converts ThinkingConfig into provider stream options, or undefined if thinking is off. */
+	#buildStreamOptions(): ProviderStreamOptions | undefined {
+		const thinking = this.#config.thinking;
+		if (!thinking || thinking.mode === "off") return undefined;
+
+		return {
+			thinkingEnabled: true,
+			...(thinking.effort && { effort: thinking.effort }),
+			...(thinking.budgetTokens && { thinkingBudgetTokens: thinking.budgetTokens }),
 		};
 	}
 
@@ -353,7 +369,7 @@ export class Session {
 		iteration: number,
 		onProgress?: OnProgress,
 	): Promise<{ done: true; result: AskResult } | { done: false }> {
-		const outcome = await processStream(this.#stream, this.#config.model, this.#context, onProgress);
+		const outcome = await processStream(this.#stream, this.#config.model, this.#context, onProgress, this.#buildStreamOptions());
 
 		if (!outcome.ok) {
 			this.#logger.error(`API call failed (iteration ${iteration + 1})`, {

--- a/src/session.ts
+++ b/src/session.ts
@@ -369,7 +369,13 @@ export class Session {
 		iteration: number,
 		onProgress?: OnProgress,
 	): Promise<{ done: true; result: AskResult } | { done: false }> {
-		const outcome = await processStream(this.#stream, this.#config.model, this.#context, onProgress, this.#buildStreamOptions());
+		const outcome = await processStream(
+			this.#stream,
+			this.#config.model,
+			this.#context,
+			onProgress,
+			this.#buildStreamOptions(),
+		);
 
 		if (!outcome.ok) {
 			this.#logger.error(`API call failed (iteration ${iteration + 1})`, {

--- a/src/session.ts
+++ b/src/session.ts
@@ -5,16 +5,16 @@ import {
 	type Context,
 	type Message,
 	type Model,
-	type SimpleStreamOptions,
+	stream,
 	streamSimple,
-	type ThinkingLevel,
 	type Tool,
 } from "@mariozechner/pi-ai";
 import { type CompactionSettings, maybeCompact } from "./compaction";
+import type { ThinkingConfig } from "./config";
 import { cleanupWorktree, type Repo } from "./forge";
 import { consoleLogger, type Logger } from "./logger";
 import { type ParsedLink, validateLinks } from "./response-validation";
-import { processStream } from "./stream-processor";
+import { processStream, type StreamFn } from "./stream-processor";
 
 // =============================================================================
 // Types
@@ -44,6 +44,8 @@ export interface AskResult {
 	totalLinks: number;
 	/** Links in the response whose repo-relative paths could not be found on disk */
 	invalidLinks: InvalidLink[];
+	/** The effort level the model actually used (from response output_config). Undefined if thinking is off. */
+	responseEffort?: string;
 }
 
 /** A link in the response that points to a non-existent file path */
@@ -140,6 +142,14 @@ interface AskContext {
 	toolCalls: ToolCallRecord[];
 	usage: Usage;
 	startTime: number;
+	/** Last response effort extracted from output_config (set per-iteration). */
+	responseEffort?: string;
+}
+
+/** Extract the effort level from pi-ai's AssistantMessage (patched to include outputConfig). */
+function extractResponseEffort(response: AssistantMessage): string | undefined {
+	const msg = response as unknown as { outputConfig?: { effort?: string } };
+	return msg.outputConfig?.effort;
 }
 
 function buildResult(
@@ -155,6 +165,7 @@ function buildResult(
 		inferenceTimeMs: Date.now() - ctx.startTime,
 		totalLinks: linkStats.totalLinks,
 		invalidLinks: linkStats.invalidLinks,
+		responseEffort: ctx.responseEffort,
 	};
 }
 
@@ -179,12 +190,14 @@ export interface SessionConfig {
 	executeTool: (name: string, args: Record<string, unknown>, cwd: string) => Promise<string>;
 	/** Logger for debug output (defaults to consoleLogger) */
 	logger?: Logger;
-	/** Stream function for AI inference (defaults to pi-ai's streamSimple) */
-	stream?: typeof streamSimple;
+	/** Raw stream function for AI inference (defaults to pi-ai's stream). Used for adaptive thinking. */
+	stream?: StreamFn;
+	/** Simple stream function (defaults to pi-ai's streamSimple). Used for level-based thinking. */
+	streamSimple?: StreamFn;
 	/** Context compaction settings (defaults to sensible values) */
 	compaction?: Partial<CompactionSettings>;
-	/** Reasoning/thinking level. If omitted, thinking is off. */
-	reasoning?: ThinkingLevel;
+	/** Thinking configuration. If omitted, thinking is off. */
+	thinking?: ThinkingConfig;
 }
 
 /**
@@ -212,7 +225,8 @@ export class Session {
 
 	#config: SessionConfig;
 	#logger: Logger;
-	#stream: typeof streamSimple;
+	#stream: StreamFn;
+	#streamSimple: StreamFn;
 	#context: Context;
 	#pending: Promise<AskResult> | null = null;
 	#closed = false;
@@ -223,7 +237,8 @@ export class Session {
 		this.repo = repo;
 		this.#config = config;
 		this.#logger = config.logger ?? consoleLogger;
-		this.#stream = config.stream ?? streamSimple;
+		this.#stream = (config.stream ?? stream) as StreamFn;
+		this.#streamSimple = (config.streamSimple ?? streamSimple) as StreamFn;
 		this.#context = {
 			systemPrompt: config.systemPrompt,
 			messages: [],
@@ -231,11 +246,22 @@ export class Session {
 		};
 	}
 
-	/** Builds SimpleStreamOptions with reasoning level if configured. */
-	#buildStreamOptions(): SimpleStreamOptions | undefined {
-		const { reasoning } = this.#config;
-		if (!reasoning) return undefined;
-		return { reasoning };
+	/** Resolves which stream function and options to use based on thinking config. */
+	#resolveStreamCall(): { streamFn: StreamFn; streamOptions?: Record<string, unknown> } {
+		const thinking = this.#config.thinking;
+		if (!thinking) return { streamFn: this.#stream };
+
+		if (thinking.level === "adaptive") {
+			return { streamFn: this.#stream, streamOptions: { thinkingEnabled: true } };
+		}
+
+		return {
+			streamFn: this.#streamSimple,
+			streamOptions: {
+				reasoning: thinking.level,
+				...(thinking.budgetOverrides && { thinkingBudgets: thinking.budgetOverrides }),
+			},
+		};
 	}
 
 	/**
@@ -364,13 +390,8 @@ export class Session {
 		iteration: number,
 		onProgress?: OnProgress,
 	): Promise<{ done: true; result: AskResult } | { done: false }> {
-		const outcome = await processStream(
-			this.#stream,
-			this.#config.model,
-			this.#context,
-			onProgress,
-			this.#buildStreamOptions(),
-		);
+		const { streamFn, streamOptions } = this.#resolveStreamCall();
+		const outcome = await processStream(streamFn, this.#config.model, this.#context, onProgress, streamOptions);
 
 		if (!outcome.ok) {
 			this.#logger.error(`API call failed (iteration ${iteration + 1})`, {
@@ -386,6 +407,10 @@ export class Session {
 
 		const response = outcome.response;
 		accumulateUsage(ctx.usage, response);
+
+		// Capture the response effort from the patched output_config (last iteration wins)
+		const effort = extractResponseEffort(response);
+		if (effort) ctx.responseEffort = effort;
 
 		// Check for API error in response (fields may exist but not be in pi-ai's public types)
 		const apiError = response as unknown as { stopReason?: string; errorMessage?: string };

--- a/src/session.ts
+++ b/src/session.ts
@@ -5,12 +5,12 @@ import {
 	type Context,
 	type Message,
 	type Model,
-	type ProviderStreamOptions,
-	stream,
+	type SimpleStreamOptions,
+	streamSimple,
+	type ThinkingLevel,
 	type Tool,
 } from "@mariozechner/pi-ai";
 import { type CompactionSettings, maybeCompact } from "./compaction";
-import type { ThinkingConfig } from "./config";
 import { cleanupWorktree, type Repo } from "./forge";
 import { consoleLogger, type Logger } from "./logger";
 import { type ParsedLink, validateLinks } from "./response-validation";
@@ -179,12 +179,12 @@ export interface SessionConfig {
 	executeTool: (name: string, args: Record<string, unknown>, cwd: string) => Promise<string>;
 	/** Logger for debug output (defaults to consoleLogger) */
 	logger?: Logger;
-	/** Stream function for AI inference (defaults to pi-ai's stream) */
-	stream?: typeof stream;
+	/** Stream function for AI inference (defaults to pi-ai's streamSimple) */
+	stream?: typeof streamSimple;
 	/** Context compaction settings (defaults to sensible values) */
 	compaction?: Partial<CompactionSettings>;
-	/** Thinking configuration (defaults to off) */
-	thinking?: ThinkingConfig;
+	/** Reasoning/thinking level. If omitted, thinking is off. */
+	reasoning?: ThinkingLevel;
 }
 
 /**
@@ -212,7 +212,7 @@ export class Session {
 
 	#config: SessionConfig;
 	#logger: Logger;
-	#stream: typeof stream;
+	#stream: typeof streamSimple;
 	#context: Context;
 	#pending: Promise<AskResult> | null = null;
 	#closed = false;
@@ -223,7 +223,7 @@ export class Session {
 		this.repo = repo;
 		this.#config = config;
 		this.#logger = config.logger ?? consoleLogger;
-		this.#stream = config.stream ?? stream;
+		this.#stream = config.stream ?? streamSimple;
 		this.#context = {
 			systemPrompt: config.systemPrompt,
 			messages: [],
@@ -231,16 +231,11 @@ export class Session {
 		};
 	}
 
-	/** Converts ThinkingConfig into provider stream options, or undefined if thinking is off. */
-	#buildStreamOptions(): ProviderStreamOptions | undefined {
-		const thinking = this.#config.thinking;
-		if (!thinking || thinking.mode === "off") return undefined;
-
-		return {
-			thinkingEnabled: true,
-			...(thinking.effort && { effort: thinking.effort }),
-			...(thinking.budgetTokens && { thinkingBudgetTokens: thinking.budgetTokens }),
-		};
+	/** Builds SimpleStreamOptions with reasoning level if configured. */
+	#buildStreamOptions(): SimpleStreamOptions | undefined {
+		const { reasoning } = this.#config;
+		if (!reasoning) return undefined;
+		return { reasoning };
 	}
 
 	/**

--- a/src/stream-processor.ts
+++ b/src/stream-processor.ts
@@ -1,11 +1,4 @@
-import type {
-	Api,
-	AssistantMessage,
-	Context,
-	streamSimple as defaultStream,
-	Model,
-	SimpleStreamOptions,
-} from "@mariozechner/pi-ai";
+import type { Api, AssistantMessage, AssistantMessageEventStream, Context, Model } from "@mariozechner/pi-ai";
 import type { OnProgress, ProgressEvent } from "./session";
 
 // =============================================================================
@@ -161,6 +154,17 @@ function handleStreamEvent(
 }
 
 // =============================================================================
+// Stream function type
+// =============================================================================
+
+/** Stream function signature that accepts both stream() and streamSimple(). */
+export type StreamFn = (
+	model: Model<Api>,
+	context: Context,
+	options?: Record<string, unknown>,
+) => AssistantMessageEventStream;
+
+// =============================================================================
 // Main Function
 // =============================================================================
 
@@ -174,11 +178,11 @@ function handleStreamEvent(
  * @returns StreamOutcome - either success with response, or error with details
  */
 export async function processStream(
-	streamFn: typeof defaultStream,
+	streamFn: StreamFn,
 	model: Model<Api>,
 	context: Context,
 	onProgress?: OnProgress,
-	streamOptions?: SimpleStreamOptions,
+	streamOptions?: Record<string, unknown>,
 ): Promise<StreamOutcome> {
 	const toolCallNames = new Map<number, string>();
 

--- a/src/stream-processor.ts
+++ b/src/stream-processor.ts
@@ -1,4 +1,4 @@
-import type { Api, AssistantMessage, Context, stream as defaultStream, Model } from "@mariozechner/pi-ai";
+import type { Api, AssistantMessage, Context, stream as defaultStream, Model, ProviderStreamOptions } from "@mariozechner/pi-ai";
 import type { OnProgress, ProgressEvent } from "./session";
 
 // =============================================================================
@@ -171,11 +171,12 @@ export async function processStream(
 	model: Model<Api>,
 	context: Context,
 	onProgress?: OnProgress,
+	streamOptions?: ProviderStreamOptions,
 ): Promise<StreamOutcome> {
 	const toolCallNames = new Map<number, string>();
 
 	try {
-		const eventStream = streamFn(model, context);
+		const eventStream = streamFn(model, context, streamOptions);
 
 		for await (const event of eventStream) {
 			const error = handleStreamEvent(event as RawStreamEvent, toolCallNames, onProgress);

--- a/src/stream-processor.ts
+++ b/src/stream-processor.ts
@@ -1,4 +1,11 @@
-import type { Api, AssistantMessage, Context, stream as defaultStream, Model, ProviderStreamOptions } from "@mariozechner/pi-ai";
+import type {
+	Api,
+	AssistantMessage,
+	Context,
+	stream as defaultStream,
+	Model,
+	ProviderStreamOptions,
+} from "@mariozechner/pi-ai";
 import type { OnProgress, ProgressEvent } from "./session";
 
 // =============================================================================

--- a/src/stream-processor.ts
+++ b/src/stream-processor.ts
@@ -2,9 +2,9 @@ import type {
 	Api,
 	AssistantMessage,
 	Context,
-	stream as defaultStream,
+	streamSimple as defaultStream,
 	Model,
-	ProviderStreamOptions,
+	SimpleStreamOptions,
 } from "@mariozechner/pi-ai";
 import type { OnProgress, ProgressEvent } from "./session";
 
@@ -178,7 +178,7 @@ export async function processStream(
 	model: Model<Api>,
 	context: Context,
 	onProgress?: OnProgress,
-	streamOptions?: ProviderStreamOptions,
+	streamOptions?: SimpleStreamOptions,
 ): Promise<StreamOutcome> {
 	const toolCallNames = new Map<number, string>();
 

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -232,7 +232,7 @@ describe("Session", () => {
 			expect(streamCalled).toBe(true);
 		});
 
-		test("passes thinking options to stream function when thinking is adaptive", async () => {
+		test("passes reasoning level to stream function", async () => {
 			let capturedOptions: unknown;
 			const customStream = ((_model: unknown, _context: unknown, options?: unknown) => {
 				capturedOptions = options;
@@ -244,40 +244,16 @@ describe("Session", () => {
 				repo,
 				createMockConfig({
 					stream: customStream,
-					thinking: { mode: "adaptive", effort: "high" },
+					reasoning: "high",
 				}),
 			);
 
 			await session.ask("Test");
 
-			expect(capturedOptions).toEqual({
-				thinkingEnabled: true,
-				effort: "high",
-			});
+			expect(capturedOptions).toEqual({ reasoning: "high" });
 		});
 
-		test("does not pass thinking options when thinking is off", async () => {
-			let capturedOptions: unknown = "sentinel";
-			const customStream = ((_model: unknown, _context: unknown, options?: unknown) => {
-				capturedOptions = options;
-				return createMockStreamResult();
-			}) as unknown as SessionConfig["stream"];
-
-			const repo = createMockRepo();
-			const session = new Session(
-				repo,
-				createMockConfig({
-					stream: customStream,
-					thinking: { mode: "off" },
-				}),
-			);
-
-			await session.ask("Test");
-
-			expect(capturedOptions).toBeUndefined();
-		});
-
-		test("does not pass thinking options when no thinking config provided", async () => {
+		test("does not pass stream options when no reasoning configured", async () => {
 			let capturedOptions: unknown = "sentinel";
 			const customStream = ((_model: unknown, _context: unknown, options?: unknown) => {
 				capturedOptions = options;

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -232,28 +232,90 @@ describe("Session", () => {
 			expect(streamCalled).toBe(true);
 		});
 
-		test("passes reasoning level to stream function", async () => {
+		test("adaptive thinking uses stream() with thinkingEnabled", async () => {
 			let capturedOptions: unknown;
+			let streamCalled = false;
+			let streamSimpleCalled = false;
 			const customStream = ((_model: unknown, _context: unknown, options?: unknown) => {
+				streamCalled = true;
 				capturedOptions = options;
 				return createMockStreamResult();
 			}) as unknown as SessionConfig["stream"];
+			const customStreamSimple = ((_model: unknown, _context: unknown, _options?: unknown) => {
+				streamSimpleCalled = true;
+				return createMockStreamResult();
+			}) as unknown as SessionConfig["streamSimple"];
 
 			const repo = createMockRepo();
 			const session = new Session(
 				repo,
 				createMockConfig({
 					stream: customStream,
-					reasoning: "high",
+					streamSimple: customStreamSimple,
+					thinking: { level: "adaptive" },
 				}),
 			);
 
 			await session.ask("Test");
 
+			expect(streamCalled).toBe(true);
+			expect(streamSimpleCalled).toBe(false);
+			expect(capturedOptions).toEqual({ thinkingEnabled: true });
+		});
+
+		test("level-based thinking uses streamSimple() with reasoning option", async () => {
+			let capturedOptions: unknown;
+			let streamCalled = false;
+			let streamSimpleCalled = false;
+			const customStream = ((_model: unknown, _context: unknown, _options?: unknown) => {
+				streamCalled = true;
+				return createMockStreamResult();
+			}) as unknown as SessionConfig["stream"];
+			const customStreamSimple = ((_model: unknown, _context: unknown, options?: unknown) => {
+				streamSimpleCalled = true;
+				capturedOptions = options;
+				return createMockStreamResult();
+			}) as unknown as SessionConfig["streamSimple"];
+
+			const repo = createMockRepo();
+			const session = new Session(
+				repo,
+				createMockConfig({
+					stream: customStream,
+					streamSimple: customStreamSimple,
+					thinking: { level: "high" },
+				}),
+			);
+
+			await session.ask("Test");
+
+			expect(streamCalled).toBe(false);
+			expect(streamSimpleCalled).toBe(true);
 			expect(capturedOptions).toEqual({ reasoning: "high" });
 		});
 
-		test("does not pass stream options when no reasoning configured", async () => {
+		test("level-based thinking passes budgetOverrides as thinkingBudgets", async () => {
+			let capturedOptions: unknown;
+			const customStreamSimple = ((_model: unknown, _context: unknown, options?: unknown) => {
+				capturedOptions = options;
+				return createMockStreamResult();
+			}) as unknown as SessionConfig["streamSimple"];
+
+			const repo = createMockRepo();
+			const session = new Session(
+				repo,
+				createMockConfig({
+					streamSimple: customStreamSimple,
+					thinking: { level: "medium", budgetOverrides: { medium: 8000 } },
+				}),
+			);
+
+			await session.ask("Test");
+
+			expect(capturedOptions).toEqual({ reasoning: "medium", thinkingBudgets: { medium: 8000 } });
+		});
+
+		test("no thinking config uses stream() with no options", async () => {
 			let capturedOptions: unknown = "sentinel";
 			const customStream = ((_model: unknown, _context: unknown, options?: unknown) => {
 				capturedOptions = options;
@@ -266,6 +328,25 @@ describe("Session", () => {
 			await session.ask("Test");
 
 			expect(capturedOptions).toBeUndefined();
+		});
+
+		test("extracts responseEffort from patched AssistantMessage", async () => {
+			const mockResult = createMockStreamResult();
+			const originalResult = mockResult.result;
+			mockResult.result = async () => {
+				const msg = await originalResult();
+				// Simulate pi-ai patch: outputConfig stashed on AssistantMessage
+				(msg as Record<string, unknown>).outputConfig = { effort: "medium" };
+				return msg;
+			};
+			const customStream = (() => mockResult) as unknown as SessionConfig["stream"];
+
+			const repo = createMockRepo();
+			const session = new Session(repo, createMockConfig({ stream: customStream }));
+
+			const result = await session.ask("Test");
+
+			expect(result.responseEffort).toBe("medium");
 		});
 	});
 });

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -285,10 +285,7 @@ describe("Session", () => {
 			}) as unknown as SessionConfig["stream"];
 
 			const repo = createMockRepo();
-			const session = new Session(
-				repo,
-				createMockConfig({ stream: customStream }),
-			);
+			const session = new Session(repo, createMockConfig({ stream: customStream }));
 
 			await session.ask("Test");
 

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -231,5 +231,68 @@ describe("Session", () => {
 
 			expect(streamCalled).toBe(true);
 		});
+
+		test("passes thinking options to stream function when thinking is adaptive", async () => {
+			let capturedOptions: unknown;
+			const customStream = ((_model: unknown, _context: unknown, options?: unknown) => {
+				capturedOptions = options;
+				return createMockStreamResult();
+			}) as unknown as SessionConfig["stream"];
+
+			const repo = createMockRepo();
+			const session = new Session(
+				repo,
+				createMockConfig({
+					stream: customStream,
+					thinking: { mode: "adaptive", effort: "high" },
+				}),
+			);
+
+			await session.ask("Test");
+
+			expect(capturedOptions).toEqual({
+				thinkingEnabled: true,
+				effort: "high",
+			});
+		});
+
+		test("does not pass thinking options when thinking is off", async () => {
+			let capturedOptions: unknown = "sentinel";
+			const customStream = ((_model: unknown, _context: unknown, options?: unknown) => {
+				capturedOptions = options;
+				return createMockStreamResult();
+			}) as unknown as SessionConfig["stream"];
+
+			const repo = createMockRepo();
+			const session = new Session(
+				repo,
+				createMockConfig({
+					stream: customStream,
+					thinking: { mode: "off" },
+				}),
+			);
+
+			await session.ask("Test");
+
+			expect(capturedOptions).toBeUndefined();
+		});
+
+		test("does not pass thinking options when no thinking config provided", async () => {
+			let capturedOptions: unknown = "sentinel";
+			const customStream = ((_model: unknown, _context: unknown, options?: unknown) => {
+				capturedOptions = options;
+				return createMockStreamResult();
+			}) as unknown as SessionConfig["stream"];
+
+			const repo = createMockRepo();
+			const session = new Session(
+				repo,
+				createMockConfig({ stream: customStream }),
+			);
+
+			await session.ask("Test");
+
+			expect(capturedOptions).toBeUndefined();
+		});
 	});
 });

--- a/test/stream-processor.test.ts
+++ b/test/stream-processor.test.ts
@@ -23,6 +23,23 @@ function createMockStreamFn(events: { type: string; [key: string]: unknown }[], 
 	})) as unknown as typeof import("@mariozechner/pi-ai").stream;
 }
 
+// Helper to create a mock stream function that captures the options it receives
+function createCapturingStreamFn(events: { type: string; [key: string]: unknown }[], response: AssistantMessage) {
+	let capturedOptions: unknown;
+	const streamFn = ((_model: unknown, _context: unknown, options?: unknown) => {
+		capturedOptions = options;
+		return {
+			[Symbol.asyncIterator]: async function* () {
+				for (const event of events) {
+					yield event;
+				}
+			},
+			result: async () => response,
+		};
+	}) as unknown as typeof import("@mariozechner/pi-ai").stream;
+	return { streamFn, getCapturedOptions: () => capturedOptions };
+}
+
 // Helper to create a mock response
 function createMockResponse(text: string): AssistantMessage {
 	return {
@@ -265,6 +282,30 @@ describe("processStream", () => {
 			const outcome = await processStream(streamFn, mockModel, mockContext);
 
 			expect(outcome.ok).toBe(true);
+		});
+	});
+
+	describe("stream options", () => {
+		test("forwards streamOptions to streamFn", async () => {
+			const events = [{ type: "text_delta", delta: "Hello" }];
+			const response = createMockResponse("Hello");
+			const { streamFn, getCapturedOptions } = createCapturingStreamFn(events, response);
+
+			const streamOptions = { thinkingEnabled: true, effort: "high" };
+			const outcome = await processStream(streamFn, mockModel, mockContext, undefined, streamOptions);
+
+			expect(outcome.ok).toBe(true);
+			expect(getCapturedOptions()).toEqual(streamOptions);
+		});
+
+		test("passes undefined when no streamOptions provided", async () => {
+			const events = [{ type: "text_delta", delta: "Hello" }];
+			const response = createMockResponse("Hello");
+			const { streamFn, getCapturedOptions } = createCapturingStreamFn(events, response);
+
+			await processStream(streamFn, mockModel, mockContext);
+
+			expect(getCapturedOptions()).toBeUndefined();
 		});
 	});
 });

--- a/test/stream-processor.test.ts
+++ b/test/stream-processor.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import type { Api, AssistantMessage, Context, Model } from "@mariozechner/pi-ai";
 import type { ProgressEvent } from "../src/session";
-import { processStream } from "../src/stream-processor";
+import { processStream, type StreamFn } from "../src/stream-processor";
 
 // Mock model and context
 const mockModel = {} as Model<Api>;
@@ -20,7 +20,7 @@ function createMockStreamFn(events: { type: string; [key: string]: unknown }[], 
 			}
 		},
 		result: async () => response,
-	})) as unknown as typeof import("@mariozechner/pi-ai").streamSimple;
+	})) as unknown as StreamFn;
 }
 
 // Helper to create a mock stream function that captures the options it receives
@@ -36,7 +36,7 @@ function createCapturingStreamFn(events: { type: string; [key: string]: unknown 
 			},
 			result: async () => response,
 		};
-	}) as unknown as typeof import("@mariozechner/pi-ai").streamSimple;
+	}) as unknown as StreamFn;
 	return { streamFn, getCapturedOptions: () => capturedOptions };
 }
 
@@ -223,7 +223,7 @@ describe("processStream", () => {
 					},
 				}),
 				result: async () => createMockResponse("Never reached"),
-			})) as unknown as typeof import("@mariozechner/pi-ai").streamSimple;
+			})) as unknown as StreamFn;
 
 			const outcome = await processStream(streamFn, mockModel, mockContext);
 
@@ -291,7 +291,7 @@ describe("processStream", () => {
 			const response = createMockResponse("Hello");
 			const { streamFn, getCapturedOptions } = createCapturingStreamFn(events, response);
 
-			const streamOptions = { reasoning: "high" as const };
+			const streamOptions = { thinkingEnabled: true };
 			const outcome = await processStream(streamFn, mockModel, mockContext, undefined, streamOptions);
 
 			expect(outcome.ok).toBe(true);

--- a/test/stream-processor.test.ts
+++ b/test/stream-processor.test.ts
@@ -20,7 +20,7 @@ function createMockStreamFn(events: { type: string; [key: string]: unknown }[], 
 			}
 		},
 		result: async () => response,
-	})) as unknown as typeof import("@mariozechner/pi-ai").stream;
+	})) as unknown as typeof import("@mariozechner/pi-ai").streamSimple;
 }
 
 // Helper to create a mock stream function that captures the options it receives
@@ -36,7 +36,7 @@ function createCapturingStreamFn(events: { type: string; [key: string]: unknown 
 			},
 			result: async () => response,
 		};
-	}) as unknown as typeof import("@mariozechner/pi-ai").stream;
+	}) as unknown as typeof import("@mariozechner/pi-ai").streamSimple;
 	return { streamFn, getCapturedOptions: () => capturedOptions };
 }
 
@@ -223,7 +223,7 @@ describe("processStream", () => {
 					},
 				}),
 				result: async () => createMockResponse("Never reached"),
-			})) as unknown as typeof import("@mariozechner/pi-ai").stream;
+			})) as unknown as typeof import("@mariozechner/pi-ai").streamSimple;
 
 			const outcome = await processStream(streamFn, mockModel, mockContext);
 
@@ -291,7 +291,7 @@ describe("processStream", () => {
 			const response = createMockResponse("Hello");
 			const { streamFn, getCapturedOptions } = createCapturingStreamFn(events, response);
 
-			const streamOptions = { thinkingEnabled: true, effort: "high" };
+			const streamOptions = { reasoning: "high" as const };
 			const outcome = await processStream(streamFn, mockModel, mockContext, undefined, streamOptions);
 
 			expect(outcome.ok).toBe(true);


### PR DESCRIPTION
- The config plumbs through AskForgeClient → Session → processStream → pi-ai stream().
- The eval runner accepts a --thinking flag for A/B comparison runs.

Implements #38 