### PR TITLE
fix(tracing): nest tool call spans under gen_ai.chat span

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -490,6 +490,28 @@ export class Session {
 			};
 		}
 
+		this.#context.messages.push(response);
+
+		// Check if we have a final text response (no tool calls)
+		const responseToolCalls = response.content.filter((b) => b.type === "toolCall");
+		if (responseToolCalls.length === 0) {
+			endGenerationSpan(genSpan, {
+				output: response.content,
+				inputTokens: response.usage?.input ?? 0,
+				outputTokens: response.usage?.output ?? 0,
+				cacheReadTokens: response.usage?.cacheRead ?? 0,
+				cacheCreationTokens: response.usage?.cacheWrite ?? 0,
+				stopReason: (response as unknown as { stopReason?: string }).stopReason,
+			});
+			return {
+				done: true,
+				result: this.#buildTextResponse(ctx, response, onProgress),
+			};
+		}
+
+		// Execute tool calls as children of this gen_ai.chat span
+		await this.#executeToolCalls(responseToolCalls, ctx.toolCalls, genSpan);
+
 		endGenerationSpan(genSpan, {
 			output: response.content,
 			inputTokens: response.usage?.input ?? 0,
@@ -498,20 +520,6 @@ export class Session {
 			cacheCreationTokens: response.usage?.cacheWrite ?? 0,
 			stopReason: (response as unknown as { stopReason?: string }).stopReason,
 		});
-
-		this.#context.messages.push(response);
-
-		// Check if we have a final text response (no tool calls)
-		const responseToolCalls = response.content.filter((b) => b.type === "toolCall");
-		if (responseToolCalls.length === 0) {
-			return {
-				done: true,
-				result: this.#buildTextResponse(ctx, response, onProgress),
-			};
-		}
-
-		// Execute tool calls
-		await this.#executeToolCalls(responseToolCalls, ctx.toolCalls, askSpan);
 
 		return { done: false };
 	}

--- a/test/tracing.test.ts
+++ b/test/tracing.test.ts
@@ -507,7 +507,7 @@ describe("OTel tracing", () => {
 			expect(names).toEqual(["fd", "rg"]);
 		});
 
-		test("tool spans are children of ask span", async () => {
+		test("tool spans are children of the gen_ai.chat span that triggered them", async () => {
 			let callCount = 0;
 			const streamFn = (() => {
 				callCount++;
@@ -518,9 +518,9 @@ describe("OTel tracing", () => {
 			const session = new Session(createMockRepo(), createMockConfig({ stream: streamFn }));
 			await session.ask("Search");
 
-			const askSpan = recorder.getSpan("ask");
+			const chatSpan = recorder.getSpans("gen_ai.chat")[0];
 			const toolSpan = recorder.getSpans("gen_ai.execute_tool")[0];
-			expect(toolSpan?.parentSpanId).toBe(askSpan?.spanId);
+			expect(toolSpan?.parentSpanId).toBe(chatSpan?.spanId);
 		});
 	});
 


### PR DESCRIPTION
Tool call spans are now children of the `gen_ai.chat` generation span that triggered them, instead of the parent `ask` span.

**Changes:**
- Pass `genSpan` (instead of `askSpan`) as the parent when executing tool calls
- Move `endGenerationSpan` to after tool execution, so tool spans fall within the generation span's time range
- Update tracing test to assert tool spans are children of the `gen_ai.chat` span

This gives a more accurate trace hierarchy: `ask → gen_ai.chat → gen_ai.execute_tool`.