### PR TITLE
Refactor thinking config

### DIFF
--- a/docs/src/content/docs/contributing/running-evaluations.md
+++ b/docs/src/content/docs/contributing/running-evaluations.md
@@ -18,6 +18,15 @@ huggingface-cli download nilenso/ask-forge-eval-dataset --repo-type dataset --lo
 
 ```bash
 bun run scripts/eval/run-eval.ts ./eval-data/ask-forge-eval-dataset.csv
+
+# With effort-based thinking (any provider)
+bun run scripts/eval/run-eval.ts ./eval-data/ask-forge-eval-dataset.csv --effort high
+
+# With adaptive thinking (Anthropic 4.6 only)
+bun run scripts/eval/run-eval.ts ./eval-data/ask-forge-eval-dataset.csv --thinking adaptive
+
+# Adaptive with explicit effort guidance
+bun run scripts/eval/run-eval.ts ./eval-data/ask-forge-eval-dataset.csv --thinking adaptive --effort medium
 ```
 
 Results are written to `scripts/eval/reports/`.

--- a/docs/src/content/docs/guides/configuration.md
+++ b/docs/src/content/docs/guides/configuration.md
@@ -120,6 +120,52 @@ When enabled, repository cloning and all tool execution (file reads, searches, g
 
 See the [Sandboxed Execution guide](/ask-forge/guides/sandbox/) for security layers, architecture, and how to run the sandbox server.
 
+### Thinking
+
+Control the model's reasoning/thinking behavior via the `thinking` field. Ask Forge supports two modes:
+
+- **Effort-based** (cross-provider): Set an effort level that pi-ai maps to each provider's native format (`reasoning.effort` for OpenAI, `thinking` for Anthropic, etc.)
+- **Adaptive** (Anthropic 4.6 only): The model decides when and how much to think per request
+
+```ts
+// OpenAI — effort-based reasoning
+const client = new AskForgeClient({
+  provider: "openai",
+  model: "o3",
+  thinking: { effort: "low" },
+});
+
+// Anthropic 4.5 — effort-based (older model, no adaptive support)
+const client = new AskForgeClient({
+  provider: "anthropic",
+  model: "claude-sonnet-4-5-20251022",
+  thinking: { effort: "high", budgetOverrides: { high: 10000 } },
+});
+
+// Anthropic 4.6 — adaptive (model decides when/how much to think)
+const client = new AskForgeClient({
+  provider: "anthropic",
+  model: "claude-sonnet-4-6",
+  thinking: { type: "adaptive" },
+});
+
+// Anthropic 4.6 — adaptive with explicit effort guidance
+const client = new AskForgeClient({
+  provider: "anthropic",
+  model: "claude-sonnet-4-6",
+  thinking: { type: "adaptive", effort: "medium" },
+});
+
+// No thinking (default)
+const client = new AskForgeClient();
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `type` | `"adaptive"` | Anthropic 4.6 only. Omit for effort-based mode. |
+| `effort` | `"minimal" \| "low" \| "medium" \| "high" \| "xhigh"` | Required for effort-based, optional for adaptive. |
+| `budgetOverrides` | `ThinkingBudgets` | Custom token budgets per level (effort-based only). |
+
 ### Context Compaction
 
 When conversations grow long, ask-forge can automatically summarize older messages to stay within the model's context window. This is enabled by default.

--- a/scripts/eval/run-eval.ts
+++ b/scripts/eval/run-eval.ts
@@ -95,7 +95,7 @@ async function runEval(inputPath: string, thinking: ThinkingConfig | undefined):
 	console.log(`Reading dataset from: ${inputPath}`);
 	console.log(`Found ${rows.length} rows to evaluate`);
 	if (thinking) {
-		console.log(`Thinking: ${thinking.level}`);
+		console.log(`Thinking: ${thinking.type === "adaptive" ? "adaptive" : `effort=${thinking.effort}`}`);
 	}
 	console.log();
 
@@ -241,12 +241,13 @@ async function runEval(inputPath: string, thinking: ThinkingConfig | undefined):
 }
 
 // CLI entry point
-const VALID_LEVELS = new Set<string>(["minimal", "low", "medium", "high", "xhigh", "adaptive"]);
+const VALID_EFFORTS = new Set<string>(["minimal", "low", "medium", "high", "xhigh"]);
 
 const { values, positionals } = parseArgs({
 	args: Bun.argv,
 	options: {
 		thinking: { type: "string", default: "" },
+		effort: { type: "string", default: "" },
 	},
 	strict: true,
 	allowPositionals: true,
@@ -255,20 +256,26 @@ const { values, positionals } = parseArgs({
 const inputPath = positionals[2]; // skip bun executable and script path
 
 if (!inputPath) {
-	console.error("Usage: bun run eval/run-eval.ts <path-to-dataset.csv> [--thinking <level>]");
-	console.error("  --thinking adaptive   model decides effort (Anthropic-only)");
-	console.error("  --thinking <level>    minimal, low, medium, high, xhigh, adaptive");
+	console.error("Usage: bun run eval/run-eval.ts <path-to-dataset.csv> [--thinking adaptive] [--effort <level>]");
+	console.error("  --thinking adaptive   model decides when/how much to think (Anthropic 4.6 only)");
+	console.error("  --effort <level>      minimal, low, medium, high, xhigh (all providers)");
 	process.exit(1);
 }
 
 let thinking: ThinkingConfig | undefined;
-if (values.thinking) {
-	const level = values.thinking;
-	if (!VALID_LEVELS.has(level)) {
-		console.error(`Invalid level: "${level}". Must be one of: ${[...VALID_LEVELS].join(", ")}`);
-		process.exit(1);
-	}
-	thinking = { level: level as ThinkingLevel | "adaptive" };
+const effort = values.effort;
+if (effort && !VALID_EFFORTS.has(effort)) {
+	console.error(`Invalid --effort value: "${effort}". Must be one of: ${[...VALID_EFFORTS].join(", ")}`);
+	process.exit(1);
+}
+
+if (values.thinking === "adaptive") {
+	thinking = { type: "adaptive", ...(effort && { effort: effort as ThinkingLevel }) };
+} else if (values.thinking) {
+	console.error(`Invalid --thinking value: "${values.thinking}". Only "adaptive" is supported.`);
+	process.exit(1);
+} else if (effort) {
+	thinking = { effort: effort as ThinkingLevel };
 }
 
 await runEval(inputPath, thinking);

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,20 +13,25 @@ import type { ThinkingBudgets, ThinkingLevel } from "@mariozechner/pi-ai";
 /**
  * Configuration for reasoning/thinking.
  *
- * - ThinkingLevel ("minimal"|"low"|"medium"|"high"|"xhigh"): Works across all providers
- *   via streamSimple(). Each provider translates to its native format.
- * - "adaptive": Model decides effort per-request (Anthropic-only, uses stream() directly).
+ * - Effort-based (cross-provider): Set an effort level, mapped to each provider's native
+ *   format by pi-ai's streamSimple() (e.g., reasoning.effort for OpenAI, thinking for Anthropic/Google).
+ * - Adaptive (Anthropic 4.6 only): Model decides when/how much to think.
+ *   Uses pi-ai's stream() with thinkingEnabled.
  */
-export interface ThinkingConfig {
-	/**
-	 * Thinking level.
-	 * - ThinkingLevel: Works across all providers via streamSimple().
-	 * - "adaptive": Model decides effort per-request (Anthropic-only, uses stream() directly).
-	 */
-	level: ThinkingLevel | "adaptive";
-	/** Custom token budgets per level (for token-based providers like older Claude, Gemini). */
-	budgetOverrides?: ThinkingBudgets;
-}
+export type ThinkingConfig =
+	| {
+			/** Model decides when/how much to think (Anthropic 4.6 models only). Uses stream(). */
+			type: "adaptive";
+			/** Optional effort guidance for adaptive mode (defaults to "high" in the Anthropic API). */
+			effort?: ThinkingLevel;
+	  }
+	| {
+			type?: undefined;
+			/** Effort level. Mapped to each provider's native format by streamSimple(). */
+			effort: ThinkingLevel;
+			/** Custom token budgets per level (for token-based providers like older Claude, Gemini). */
+			budgetOverrides?: ThinkingBudgets;
+	  };
 
 export type { ThinkingBudgets, ThinkingLevel };
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -266,14 +266,21 @@ export class Session {
 		const thinking = this.#config.thinking;
 		if (!thinking) return { streamFn: this.#stream };
 
-		if (thinking.level === "adaptive") {
-			return { streamFn: this.#stream, streamOptions: { thinkingEnabled: true } };
+		if (thinking.type === "adaptive") {
+			return {
+				streamFn: this.#stream,
+				streamOptions: {
+					thinkingEnabled: true,
+					...(thinking.effort && { effort: thinking.effort }),
+				},
+			};
 		}
 
+		// Effort-based (cross-provider) — use streamSimple which maps to native format
 		return {
 			streamFn: this.#streamSimple,
 			streamOptions: {
-				reasoning: thinking.level,
+				reasoning: thinking.effort,
 				...(thinking.budgetOverrides && { thinkingBudgets: thinking.budgetOverrides }),
 			},
 		};

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -252,7 +252,7 @@ describe("Session", () => {
 				createMockConfig({
 					stream: customStream,
 					streamSimple: customStreamSimple,
-					thinking: { level: "adaptive" },
+					thinking: { type: "adaptive" },
 				}),
 			);
 
@@ -263,7 +263,28 @@ describe("Session", () => {
 			expect(capturedOptions).toEqual({ thinkingEnabled: true });
 		});
 
-		test("level-based thinking uses streamSimple() with reasoning option", async () => {
+		test("adaptive thinking with effort passes both to stream()", async () => {
+			let capturedOptions: unknown;
+			const customStream = ((_model: unknown, _context: unknown, options?: unknown) => {
+				capturedOptions = options;
+				return createMockStreamResult();
+			}) as unknown as SessionConfig["stream"];
+
+			const repo = createMockRepo();
+			const session = new Session(
+				repo,
+				createMockConfig({
+					stream: customStream,
+					thinking: { type: "adaptive", effort: "medium" },
+				}),
+			);
+
+			await session.ask("Test");
+
+			expect(capturedOptions).toEqual({ thinkingEnabled: true, effort: "medium" });
+		});
+
+		test("effort-based thinking uses streamSimple() with reasoning option", async () => {
 			let capturedOptions: unknown;
 			let streamCalled = false;
 			let streamSimpleCalled = false;
@@ -283,7 +304,7 @@ describe("Session", () => {
 				createMockConfig({
 					stream: customStream,
 					streamSimple: customStreamSimple,
-					thinking: { level: "high" },
+					thinking: { effort: "high" },
 				}),
 			);
 
@@ -294,7 +315,7 @@ describe("Session", () => {
 			expect(capturedOptions).toEqual({ reasoning: "high" });
 		});
 
-		test("level-based thinking passes budgetOverrides as thinkingBudgets", async () => {
+		test("effort-based thinking passes budgetOverrides as thinkingBudgets", async () => {
 			let capturedOptions: unknown;
 			const customStreamSimple = ((_model: unknown, _context: unknown, options?: unknown) => {
 				capturedOptions = options;
@@ -306,7 +327,7 @@ describe("Session", () => {
 				repo,
 				createMockConfig({
 					streamSimple: customStreamSimple,
-					thinking: { level: "medium", budgetOverrides: { medium: 8000 } },
+					thinking: { effort: "medium", budgetOverrides: { medium: 8000 } },
 				}),
 			);
 


### PR DESCRIPTION
- Refactor `ThinkingConfig` to decouple effort from thinking type
- Update run-eval cli to use the updated params
- Update readme to document usage of ThinkingConfig