### PR TITLE
Normalize tool crash handling

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -167,6 +167,12 @@ function extractResponseEffort(response: AssistantMessage): string | undefined {
 	return msg.outputConfig?.effort;
 }
 
+function formatToolExecutionError(toolName: string, error: unknown): string {
+	const message = error instanceof Error ? error.message : String(error);
+	const detail = message.trim() || "Unknown error";
+	return `[ERROR] Tool execution failed for ${toolName}: ${detail}`;
+}
+
 function buildResult(
 	ctx: AskContext,
 	response: string,
@@ -577,10 +583,12 @@ export class Session {
 					const result = await this.#config.executeTool(call.name, call.arguments, this.repo.localPath);
 					endToolSpan(toolSpan, result);
 					this.#logger.log(`TOOL_DONE: ${call.name}`, `${Date.now() - t0}ms`);
-					return result;
+					return { text: result, isError: false };
 				} catch (error) {
+					const errorText = formatToolExecutionError(call.name, error);
 					endToolSpanWithError(toolSpan, error);
-					throw error;
+					this.#logger.warn(`TOOL_ERROR: ${call.name}`, `${Date.now() - t0}ms ${errorText}`);
+					return { text: errorText, isError: true };
 				}
 			}),
 		);
@@ -596,8 +604,8 @@ export class Session {
 				role: "toolResult",
 				toolCallId: call.id,
 				toolName: call.name,
-				content: [{ type: "text", text: results[j] ?? "" }],
-				isError: false,
+				content: [{ type: "text", text: results[j]?.text ?? "" }],
+				isError: results[j]?.isError ?? false,
 				timestamp: Date.now(),
 			});
 		});

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -41,6 +41,44 @@ function createMockStreamResult() {
 	};
 }
 
+function createToolCallStreamResult(
+	toolCalls: { name: string; arguments: Record<string, unknown> }[] = [{ name: "rg", arguments: { pattern: "test" } }],
+) {
+	return {
+		[Symbol.asyncIterator]: async function* () {
+			for (let i = 0; i < toolCalls.length; i++) {
+				const tc = toolCalls[i];
+				yield {
+					type: "toolcall_delta",
+					delta: "",
+					contentIndex: i,
+					partial: { content: toolCalls.map((t) => ({ type: "toolCall", name: t.name })) },
+				};
+				yield {
+					type: "toolcall_end",
+					contentIndex: i,
+					toolCall: { name: tc?.name, arguments: tc?.arguments },
+				};
+			}
+		},
+		result: async () => ({
+			role: "assistant" as const,
+			content: toolCalls.map((tc, i) => ({
+				type: "toolCall" as const,
+				id: `tc${i}`,
+				name: tc.name,
+				arguments: tc.arguments,
+			})),
+			usage: { input: 100, output: 30, totalTokens: 130 },
+			timestamp: Date.now(),
+			api: "test",
+			provider: "test",
+			model: "test",
+			stopReason: "tool_use",
+		}),
+	};
+}
+
 function createMockStream(): SessionConfig["stream"] {
 	return (() => createMockStreamResult()) as unknown as SessionConfig["stream"];
 }
@@ -215,6 +253,39 @@ describe("Session", () => {
 			expect(messages.length).toBeGreaterThanOrEqual(1);
 			expect(messages[0]?.role).toBe("user");
 			expect(messages[0]?.content).toBe("Test question");
+		});
+
+		test("rejecting tool execution is fed back as an error tool result", async () => {
+			let streamCalls = 0;
+			const customStream = (() => {
+				streamCalls++;
+				if (streamCalls === 1) {
+					return createToolCallStreamResult([{ name: "rg", arguments: { pattern: "needle" } }]);
+				}
+				return createMockStreamResult();
+			}) as unknown as SessionConfig["stream"];
+
+			const repo = createMockRepo();
+			const session = new Session(
+				repo,
+				createMockConfig({
+					stream: customStream,
+					executeTool: async () => {
+						throw new Error("tool crashed");
+					},
+				}),
+			);
+
+			const result = await session.ask("Find needle");
+			expect(result.response).toBe("Hello world");
+			expect(streamCalls).toBe(2);
+
+			const toolResults = session.getMessages().filter((message) => message.role === "toolResult");
+			expect(toolResults).toHaveLength(1);
+			expect(toolResults[0]?.isError).toBe(true);
+			expect((toolResults[0]?.content[0] as { text?: string } | undefined)?.text).toBe(
+				"[ERROR] Tool execution failed for rg: tool crashed",
+			);
 		});
 
 		test("uses injected stream function", async () => {

--- a/test/tracing.test.ts
+++ b/test/tracing.test.ts
@@ -558,7 +558,7 @@ describe("OTel tracing", () => {
 			expect(askSpan?.status.code).toBe(SpanStatusCode.OK); // ask succeeded in returning a result
 		});
 
-		test("tool execution error ends tool span with error and propagates to ask span", async () => {
+		test("tool execution error ends tool span with error and still lets ask complete", async () => {
 			let callCount = 0;
 			const streamFn = (() => {
 				callCount++;
@@ -572,7 +572,8 @@ describe("OTel tracing", () => {
 
 			const session = new Session(createMockRepo(), createMockConfig({ stream: streamFn, executeTool }));
 
-			await expect(session.ask("Boom")).rejects.toThrow("tool crashed");
+			const result = await session.ask("Boom");
+			expect(result.response).toBe("Hello world");
 
 			// Tool span ended with error
 			const toolSpan = recorder.getSpans("gen_ai.execute_tool")[0];
@@ -581,11 +582,10 @@ describe("OTel tracing", () => {
 			expect(toolSpan?.exceptions.length).toBe(1);
 			expect(toolSpan?.exceptions[0]?.message).toBe("tool crashed");
 
-			// Ask span also ended with error (no orphan)
+			// Ask span still ends successfully after the model gets the tool error as context
 			const askSpan = recorder.getSpan("ask");
-			expect(askSpan?.status.code).toBe(SpanStatusCode.ERROR);
+			expect(askSpan?.status.code).toBe(SpanStatusCode.OK);
 			expect(askSpan?.ended).toBe(true);
-			expect(askSpan?.attributes["error.type"]).toBe("unexpected_error");
 		});
 
 		test("API error in response records string error as exception on generation span", async () => {


### PR DESCRIPTION
## Summary
- convert thrown tool execution failures into toolResult messages instead of aborting ask()
- mark those tool results with `isError: true` so the model can recover on the next turn
- update session and tracing tests to cover the continued ask loop behavior

## Testing
- bun test test/session.test.ts
- bun test test/tracing.test.ts

## Notes
- `bunx tsc --noEmit` currently fails due to unrelated existing errors under `docs/` and `scripts/eval/`