### PR TITLE
Record detailed span errors across failure paths

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -443,7 +443,7 @@ export class Session {
 			endAskSpanWithError(askSpan, "max_iterations_reached");
 			return result;
 		} catch (error) {
-			endAskSpanWithError(askSpan, "unexpected_error", error instanceof Error ? error : undefined);
+			endAskSpanWithError(askSpan, "unexpected_error", error);
 			throw error;
 		}
 	}
@@ -466,7 +466,7 @@ export class Session {
 		const outcome = await processStream(streamFn, this.#config.model, this.#context, onProgress, streamOptions);
 
 		if (!outcome.ok) {
-			endGenerationSpanWithError(genSpan, outcome.error);
+			endGenerationSpanWithError(genSpan, outcome.errorDetails ?? outcome.error);
 			this.#logger.error(`API call failed (iteration ${iteration + 1})`, {
 				...(typeof outcome.errorDetails === "object" ? outcome.errorDetails : { error: outcome.errorDetails }),
 				iteration: iteration + 1,
@@ -508,14 +508,20 @@ export class Session {
 		// Check if we have a final text response (no tool calls)
 		const responseToolCalls = response.content.filter((b) => b.type === "toolCall");
 		if (responseToolCalls.length === 0) {
-			endGenerationSpan(genSpan, {
-				output: response.content,
-				inputTokens: response.usage?.input ?? 0,
-				outputTokens: response.usage?.output ?? 0,
-				cacheReadTokens: response.usage?.cacheRead ?? 0,
-				cacheCreationTokens: response.usage?.cacheWrite ?? 0,
-				stopReason: (response as unknown as { stopReason?: string }).stopReason,
-			});
+			const textBlocks = response.content.filter((b) => b.type === "text");
+			const responseText = textBlocks.map((b) => (b as { type: "text"; text: string }).text).join("\n");
+			if (!responseText.trim()) {
+				endGenerationSpanWithError(genSpan, "Empty response from API");
+			} else {
+				endGenerationSpan(genSpan, {
+					output: response.content,
+					inputTokens: response.usage?.input ?? 0,
+					outputTokens: response.usage?.output ?? 0,
+					cacheReadTokens: response.usage?.cacheRead ?? 0,
+					cacheCreationTokens: response.usage?.cacheWrite ?? 0,
+					stopReason: (response as unknown as { stopReason?: string }).stopReason,
+				});
+			}
 			return {
 				done: true,
 				result: this.#buildTextResponse(ctx, response, onProgress),

--- a/src/tracing.ts
+++ b/src/tracing.ts
@@ -69,6 +69,85 @@ const EVENT = {
 	TOOL_CALL_RESULT: "gen_ai.tool.call.result",
 } as const;
 
+function stringifyUnknownError(error: unknown): string {
+	if (error === undefined) return "";
+	if (error === null) return "null";
+	if (
+		typeof error === "string" ||
+		typeof error === "number" ||
+		typeof error === "boolean" ||
+		typeof error === "bigint" ||
+		typeof error === "symbol"
+	) {
+		return String(error);
+	}
+
+	try {
+		const json = JSON.stringify(error);
+		if (json && json !== "{}") {
+			return json;
+		}
+	} catch {
+		// Fall back to String(error) below when serialization fails.
+	}
+
+	return String(error);
+}
+
+function normalizeErrorDetails(
+	error: unknown,
+	fallbackMessage: string,
+): { name: string; message: string; exception?: Error } {
+	let rawName: string | undefined;
+	let rawMessage: string | undefined;
+	let exception: Error | undefined;
+
+	if (error instanceof Error) {
+		rawName = error.name;
+		rawMessage = error.message;
+		exception = error;
+	} else if (error && typeof error === "object") {
+		const errorLike = error as { name?: unknown; message?: unknown; errorMessage?: unknown };
+		rawName = typeof errorLike.name === "string" ? errorLike.name : undefined;
+		rawMessage =
+			typeof errorLike.message === "string"
+				? errorLike.message
+				: typeof errorLike.errorMessage === "string"
+					? errorLike.errorMessage
+					: undefined;
+	} else if (typeof error === "string") {
+		rawMessage = error;
+	}
+
+	if (!rawMessage) {
+		rawMessage = stringifyUnknownError(error);
+	}
+
+	const message = rawMessage.trim() || fallbackMessage;
+	const name = rawName?.trim() || "Error";
+
+	if (!exception && error !== undefined) {
+		exception = new Error(message);
+		exception.name = name;
+	}
+
+	return { name, message, exception };
+}
+
+function annotateErrorSpan(span: Span, error: unknown, fallbackMessage: string, errorType?: string) {
+	const details = normalizeErrorDetails(error, fallbackMessage);
+	span.setAttributes({
+		...(errorType ? { [ATTR.ERROR_TYPE]: errorType } : {}),
+		[ATTR.ERROR_NAME]: details.name,
+		[ATTR.ERROR_MESSAGE]: details.message,
+	});
+	span.setStatus({ code: SpanStatusCode.ERROR, message: details.message });
+	if (details.exception) {
+		span.recordException(details.exception);
+	}
+	return details;
+}
+
 // =============================================================================
 // Span helpers — thin wrappers that return OTel Span objects
 // =============================================================================
@@ -126,12 +205,8 @@ export function endAskSpan(
 }
 
 /** End the root ask span with an error. */
-export function endAskSpanWithError(span: Span, errorType: string, error?: Error): void {
-	span.setAttributes({ [ATTR.ERROR_TYPE]: errorType });
-	span.setStatus({ code: SpanStatusCode.ERROR, message: errorType });
-	if (error) {
-		span.recordException(error);
-	}
+export function endAskSpanWithError(span: Span, errorType: string, error?: unknown): void {
+	annotateErrorSpan(span, error, errorType, errorType);
 	span.end();
 }
 
@@ -157,10 +232,7 @@ export function endCompactionSpan(
 
 /** End the compaction span with an error. */
 export function endCompactionSpanWithError(span: Span, error: unknown): void {
-	span.setStatus({ code: SpanStatusCode.ERROR, message: "compaction failed" });
-	if (error instanceof Error) {
-		span.recordException(error);
-	}
+	annotateErrorSpan(span, error, "compaction failed", "compaction_failed");
 	span.end();
 }
 
@@ -216,12 +288,7 @@ export function endGenerationSpan(
 
 /** End a generation span with an error. */
 export function endGenerationSpanWithError(span: Span, error: unknown): void {
-	span.setStatus({ code: SpanStatusCode.ERROR, message: "generation failed" });
-	if (error instanceof Error) {
-		span.recordException(error);
-	} else if (typeof error === "string") {
-		span.recordException(new Error(error));
-	}
+	annotateErrorSpan(span, error, "generation failed", "generation_failed");
 	span.end();
 }
 
@@ -259,16 +326,9 @@ export function endToolSpan(span: Span, result: string): void {
 
 /** End a tool span with an error. */
 export function endToolSpanWithError(span: Span, error: unknown, result?: string): void {
-	const exception =
-		error instanceof Error ? error : new Error(typeof error === "string" ? error : JSON.stringify(error));
+	const details = annotateErrorSpan(span, error, "tool execution failed", "tool_execution_failed");
 	span.addEvent(EVENT.TOOL_CALL_RESULT, {
-		content: result ?? exception.message,
+		content: result ?? details.message,
 	});
-	span.setAttributes({
-		[ATTR.ERROR_NAME]: exception.name,
-		[ATTR.ERROR_MESSAGE]: exception.message,
-	});
-	span.setStatus({ code: SpanStatusCode.ERROR, message: exception.message });
-	span.recordException(exception);
 	span.end();
 }

--- a/test/tracing.test.ts
+++ b/test/tracing.test.ts
@@ -275,6 +275,33 @@ function createMockConfig(overrides?: Partial<SessionConfig>): SessionConfig {
 	};
 }
 
+function expectSpanErrorDetails(
+	span: RecordedSpan | undefined,
+	{
+		errorType,
+		message,
+		name = "Error",
+		exceptionMessage = message,
+		exceptionCount = 1,
+	}: {
+		errorType: string;
+		message: string;
+		name?: string;
+		exceptionMessage?: string;
+		exceptionCount?: number;
+	},
+) {
+	expect(span?.status.code).toBe(SpanStatusCode.ERROR);
+	expect(span?.status.message).toBe(message);
+	expect(span?.attributes["error.type"]).toBe(errorType);
+	expect(span?.attributes["ask_forge.error.name"]).toBe(name);
+	expect(span?.attributes["ask_forge.error.message"]).toBe(message);
+	expect(span?.exceptions.length).toBe(exceptionCount);
+	if (exceptionCount > 0) {
+		expect(span?.exceptions[0]?.message).toBe(exceptionMessage);
+	}
+}
+
 // =============================================================================
 // Test suite
 // =============================================================================
@@ -439,8 +466,10 @@ describe("OTel tracing", () => {
 			await session.ask("Will fail");
 
 			const genSpan = recorder.getSpan("gen_ai.chat");
-			expect(genSpan?.status.code).toBe(SpanStatusCode.ERROR);
-			expect(genSpan?.exceptions.length).toBeGreaterThan(0);
+			expectSpanErrorDetails(genSpan, {
+				errorType: "generation_failed",
+				message: "Rate limit exceeded",
+			});
 		});
 	});
 
@@ -536,8 +565,11 @@ describe("OTel tracing", () => {
 			await session.ask("Loop");
 
 			const askSpan = recorder.getSpan("ask");
-			expect(askSpan?.status.code).toBe(SpanStatusCode.ERROR);
-			expect(askSpan?.attributes["error.type"]).toBe("max_iterations_reached");
+			expectSpanErrorDetails(askSpan, {
+				errorType: "max_iterations_reached",
+				message: "max_iterations_reached",
+				exceptionCount: 0,
+			});
 		});
 
 		test("API error ends both generation and ask spans properly", async () => {
@@ -551,6 +583,8 @@ describe("OTel tracing", () => {
 
 			// Generation ended with error
 			expect(genSpan?.status.code).toBe(SpanStatusCode.ERROR);
+			expect(genSpan?.attributes["error.type"]).toBe("generation_failed");
+			expect(genSpan?.attributes["ask_forge.error.message"]).toBe("Rate limit exceeded");
 			expect(genSpan?.ended).toBe(true);
 
 			// Ask span still ended (no orphan)
@@ -577,13 +611,11 @@ describe("OTel tracing", () => {
 
 			// Tool span ended with error
 			const toolSpan = recorder.getSpans("gen_ai.execute_tool")[0];
-			expect(toolSpan?.status.code).toBe(SpanStatusCode.ERROR);
-			expect(toolSpan?.status.message).toBe("tool crashed");
+			expectSpanErrorDetails(toolSpan, {
+				errorType: "tool_execution_failed",
+				message: "tool crashed",
+			});
 			expect(toolSpan?.ended).toBe(true);
-			expect(toolSpan?.attributes["ask_forge.error.name"]).toBe("Error");
-			expect(toolSpan?.attributes["ask_forge.error.message"]).toBe("tool crashed");
-			expect(toolSpan?.exceptions.length).toBe(1);
-			expect(toolSpan?.exceptions[0]?.message).toBe("tool crashed");
 			expect(toolSpan?.events.at(-1)?.name).toBe("gen_ai.tool.call.result");
 			expect(toolSpan?.events.at(-1)?.attributes?.content).toBe("[ERROR] Tool execution failed for rg: tool crashed");
 
@@ -615,41 +647,88 @@ describe("OTel tracing", () => {
 			await session.ask("Fail with API error");
 
 			const genSpan = recorder.getSpan("gen_ai.chat");
-			expect(genSpan?.status.code).toBe(SpanStatusCode.ERROR);
+			expectSpanErrorDetails(genSpan, {
+				errorType: "generation_failed",
+				message: "Rate limit exceeded",
+			});
 			expect(genSpan?.ended).toBe(true);
-			expect(genSpan?.exceptions.length).toBe(1);
-			expect(genSpan?.exceptions[0]?.message).toBe("Rate limit exceeded");
 		});
 
-		test("compaction error records exception on compaction span", async () => {
-			// We need to trigger a compaction error. The simplest way is to fill the context
-			// with enough messages to trigger compaction, then have the model call fail during compaction.
-			// Instead, we'll test at the span level by creating a session with a stream that works
-			// but making maybeCompact throw by providing an invalid model config.
+		test("empty final responses record structured details on the generation span", async () => {
+			const streamFn = (() => ({
+				[Symbol.asyncIterator]: async function* () {
+					yield { type: "text_delta", delta: "" };
+				},
+				result: async () => ({
+					role: "assistant" as const,
+					content: [{ type: "text" as const, text: "" }],
+					usage: { input: 10, output: 0, totalTokens: 10 },
+					timestamp: Date.now(),
+					api: "test",
+					provider: "test",
+					model: "test",
+					stopReason: "end_turn",
+				}),
+			})) as unknown as SessionConfig["stream"];
+
+			const session = new Session(createMockRepo(), createMockConfig({ stream: streamFn }));
+			const result = await session.ask("Return nothing");
+
+			expect(result.response).toBe("[ERROR: Empty response from API - check API key and credits]");
+
+			const genSpan = recorder.getSpan("gen_ai.chat");
+			expectSpanErrorDetails(genSpan, {
+				errorType: "generation_failed",
+				message: "Empty response from API",
+			});
+		});
+
+		test("compaction error records structured details on the compaction span", async () => {
 			const brokenModel = {
 				id: "broken",
 				provider: "broken",
-				// Missing required fields will cause maybeCompact to throw
 			} as unknown as Model<Api>;
 
 			const session = new Session(
 				createMockRepo(),
 				createMockConfig({
 					model: brokenModel,
-					// Provide a working stream so the ask can complete after compaction fails
 					stream: (() => createMockStreamResult()) as unknown as SessionConfig["stream"],
 				}),
 			);
+			session.replaceMessages([
+				{ role: "user", content: "x".repeat(400_000), timestamp: Date.now() },
+				{ role: "user", content: "y".repeat(400_000), timestamp: Date.now() + 1 },
+			]);
 
-			// This should not throw — compaction errors are caught and logged
 			await session.ask("Will compaction fail?");
 
 			const compSpan = recorder.getSpan("compaction");
 			expect(compSpan).toBeDefined();
+			expect(compSpan?.status.message).toBeTruthy();
 			expect(compSpan?.ended).toBe(true);
-			// If compaction errored, it should have ERROR status
-			// If it didn't error (model was valid enough), it should have OK status
-			// Either way, the span must be ended
+			expectSpanErrorDetails(compSpan, {
+				errorType: "compaction_failed",
+				message: String(compSpan?.status.message),
+			});
+		});
+
+		test("unexpected ask failures record structured details on the ask span", async () => {
+			const session = new Session(createMockRepo(), createMockConfig());
+
+			await expect(
+				session.ask("Explode", {
+					onProgress: () => {
+						throw new Error("progress exploded");
+					},
+				}),
+			).rejects.toThrow("progress exploded");
+
+			const askSpan = recorder.getSpan("ask");
+			expectSpanErrorDetails(askSpan, {
+				errorType: "unexpected_error",
+				message: "progress exploded",
+			});
 		});
 	});
 });


### PR DESCRIPTION
## Summary
- normalize error details for ask, compaction, generation, and tool spans so each failure path records `error.type`, `ask_forge.error.name`, `ask_forge.error.message`, and an error status message
- preserve the model-facing tool failure text on failed tool span result events
- mark empty final responses as generation failures instead of leaving the generation span successful
- add dedicated tracing assertions for each traced failure mode in `test/tracing.test.ts`

## Failure paths covered
- max iterations on the ask span
- unexpected ask failures
- compaction failures
- stream/API event failures on generation spans
- API error responses on generation spans
- empty final responses on generation spans
- tool execution failures on tool spans

## Testing
- bun test test/tracing.test.ts
- bun test test/session.test.ts

## Notes
- this builds on the merged tool-crash normalization change from #70
- `test/tracing.test.ts` now contains the span error-detail assertions directly, without relying on other test files