### PR TITLE
fix(sandbox): add line numbers and file header to read tool output

### DIFF
--- a/src/sandbox/worker.ts
+++ b/src/sandbox/worker.ts
@@ -483,7 +483,7 @@ async function handleTool(body: ToolRequest): Promise<Response> {
 			if (!fullPath) {
 				return Response.json({ ok: false, error: `invalid project path: ${path}` }, { status: 400 });
 			}
-			const result = await runToolIsolated(["cat", fullPath], worktree);
+			const result = await runToolIsolated(["cat", "-n", fullPath], worktree);
 			if (result.exitCode !== 0) {
 				return Response.json(
 					{ ok: false, error: `read failed (exit ${result.exitCode}):\n${result.stderr}` },


### PR DESCRIPTION
The sandbox worker was using plain `cat` to read files, so the read tool output in sandboxed mode (used by ask-forge-web) was missing line numbers and the [File: path] header that the non-sandbox path provides.