### PR TITLE
Bump jsr.json version to 0.0.17 to match release tag

### DIFF
--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nilenso/ask-forge",
-	"version": "0.0.15",
+	"version": "0.0.17",
 	"license": "MIT",
 	"exports": "./src/index.ts",
 	"exclude": [


### PR DESCRIPTION
The version in jsr.json was stuck at 0.0.15, causing the JSR publish to attempt publishing the wrong version.