### PR TITLE
Fix install-deps type error

### DIFF
--- a/src/cli/install-deps.ts
+++ b/src/cli/install-deps.ts
@@ -1,8 +1,10 @@
 import { spawnSync } from "node:child_process";
 import { platform } from "node:os";
 
+type DependencyName = "git" | "ripgrep" | "fd";
+
 interface Dependency {
-	name: string;
+	name: DependencyName;
 	command: string;
 	versionFlag: string;
 }
@@ -15,7 +17,7 @@ const dependencies: Dependency[] = [
 
 type PackageManager = "brew" | "apt" | "dnf" | "pacman" | "apk";
 
-const installCommands: Record<PackageManager, Record<string, string>> = {
+const installCommands: Record<PackageManager, Record<DependencyName, string>> = {
 	brew: { git: "git", ripgrep: "ripgrep", fd: "fd" },
 	apt: { git: "git", ripgrep: "ripgrep", fd: "fd-find" },
 	dnf: { git: "git", ripgrep: "ripgrep", fd: "fd-find" },


### PR DESCRIPTION
## Because
- TypeDoc build fails: `installCommands[pm][dep.name]` returns `string | undefined` because `dep.name` is typed as `string`

## This addresses
- Add `DependencyName` union type (`"git" | "ripgrep" | "fd"`)
- Use it in both `Dependency.name` and `installCommands` record to guarantee compile-time safety

## Test Plan
- [x] `bunx tsc --noEmit` — no errors in CLI files
- [x] `bun test` — all tests pass