### PR TITLE
Add module doc to CLI entrypoint for JSR score

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,3 +1,8 @@
+/**
+ * CLI for megasthenes — install system dependencies and set up the sandbox server.
+ *
+ * @module
+ */
 import { installDeps } from "./install-deps.ts";
 import { setupSandbox } from "./setup-sandbox.ts";
 


### PR DESCRIPTION
## Because
- JSR score penalises packages with undocumented entrypoints

## This addresses
- Add `@module` JSDoc comment to `src/cli/index.ts`

## Test Plan
- [x] `bun test` — all tests pass
- [x] `bunx biome check .` — no issues