### PR TITLE
feat: rename error `code` to `errorType`, add connect-time structured…

### DIFF
--- a/scripts/test-ask.ts
+++ b/scripts/test-ask.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env bun
+
 /**
  * CLI script to test the megasthenes ask() API.
  * Outputs JSON to stdout; progress/status to stderr.
@@ -22,8 +23,8 @@
  *   bun scripts/test-ask.ts file:///path/to/repo.git "Explain src/" --model claude-opus-4-6
  */
 
-import { Client, nullLogger, type SessionConfig } from "../src/index";
 import type { ThinkingConfig } from "../src/config";
+import { Client, nullLogger, type SessionConfig } from "../src/index";
 
 // ---------------------------------------------------------------------------
 // Arg parsing
@@ -41,7 +42,7 @@ function flag(name: string): boolean {
 function option(name: string, fallback: string): string {
 	const i = args.indexOf(`--${name}`);
 	if (i === -1 || i + 1 >= args.length) return fallback;
-	const val = args[i + 1]!;
+	const val = args[i + 1] as string;
 	args.splice(i, 2);
 	return val;
 }
@@ -83,25 +84,21 @@ try {
 	console.log(`Session ${session.id} ready (commit: ${session.repo.commitish})`);
 	console.log(`Asking: ${prompt}\n`);
 
-	const signal = abortImmediate
-		? AbortSignal.abort()
-		: abortMs > 0
-			? AbortSignal.timeout(abortMs)
-			: undefined;
+	const signal = abortImmediate ? AbortSignal.abort() : abortMs > 0 ? AbortSignal.timeout(abortMs) : undefined;
 
 	const stream = session.ask(prompt, signal ? { signal } : undefined);
 
 	if (streamMode) {
 		for await (const event of stream) {
-			process.stdout.write(JSON.stringify(event) + "\n");
+			process.stdout.write(`${JSON.stringify(event)}\n`);
 		}
 	} else {
 		const result = await stream.result();
-		process.stdout.write(JSON.stringify(result, null, 2) + "\n");
+		process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
 	}
 
 	await session.close();
 } catch (err) {
-	process.stdout.write(JSON.stringify(err, Object.getOwnPropertyNames(err as object), 2) + "\n");
+	process.stdout.write(`${JSON.stringify(err, Object.getOwnPropertyNames(err as object), 2)}\n`);
 	process.exit(1);
 }

--- a/scripts/test-ask.ts
+++ b/scripts/test-ask.ts
@@ -1,0 +1,107 @@
+#!/usr/bin/env bun
+/**
+ * CLI script to test the megasthenes ask() API.
+ * Outputs JSON to stdout; progress/status to stderr.
+ *
+ * Usage:
+ *   bun scripts/test-ask.ts <repo-url> <prompt> [options]
+ *
+ * Options:
+ *   --provider <p>       Model provider (default: "anthropic")
+ *   --model <m>          Model ID (default: "claude-sonnet-4-6")
+ *   --max-iterations <n> Max tool-use iterations (default: 20)
+ *   --stream             Print each stream event as NDJSON instead of the final result
+ *   --commitish <ref>    Git ref to checkout (branch, tag, SHA)
+ *   --thinking <effort>  Enable thinking with effort level (e.g. "medium", "high")
+ *   --abort <ms>         Abort the turn after N milliseconds
+ *   --abort-immediate    Pass a pre-aborted signal (turn never starts)
+ *
+ * Examples:
+ *   bun scripts/test-ask.ts https://github.com/user/repo "What does this project do?"
+ *   bun scripts/test-ask.ts https://github.com/user/repo "List all files" --stream
+ *   bun scripts/test-ask.ts file:///path/to/repo.git "Explain src/" --model claude-opus-4-6
+ */
+
+import { Client, nullLogger, type SessionConfig } from "../src/index";
+import type { ThinkingConfig } from "../src/config";
+
+// ---------------------------------------------------------------------------
+// Arg parsing
+// ---------------------------------------------------------------------------
+
+const args = process.argv.slice(2);
+
+function flag(name: string): boolean {
+	const i = args.indexOf(`--${name}`);
+	if (i === -1) return false;
+	args.splice(i, 1);
+	return true;
+}
+
+function option(name: string, fallback: string): string {
+	const i = args.indexOf(`--${name}`);
+	if (i === -1 || i + 1 >= args.length) return fallback;
+	const val = args[i + 1]!;
+	args.splice(i, 2);
+	return val;
+}
+
+const streamMode = flag("stream");
+const abortImmediate = flag("abort-immediate");
+const abortMs = Number(option("abort", "0"));
+const provider = option("provider", "anthropic");
+const modelId = option("model", "claude-sonnet-4-6");
+const maxIterations = Number(option("max-iterations", "20"));
+const commitish = option("commitish", "");
+const thinkingEffort = option("thinking", "");
+
+const repoUrl = args[0];
+const prompt = args[1];
+
+if (!repoUrl || !prompt) {
+	console.error("Usage: bun scripts/test-ask.ts <repo-url> <prompt> [options]");
+	console.error("Run with no args to see the full header comment for details.");
+	process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// Run
+// ---------------------------------------------------------------------------
+
+try {
+	const client = new Client({ logger: nullLogger });
+
+	const sessionConfig: SessionConfig = {
+		repo: { url: repoUrl, ...(commitish ? { commitish } : {}) },
+		model: { provider, id: modelId },
+		maxIterations,
+		...(thinkingEffort ? { thinking: { effort: thinkingEffort } as ThinkingConfig } : {}),
+	};
+
+	console.log(`Connecting to ${repoUrl}...`);
+	const session = await client.connect(sessionConfig, (msg) => console.error(msg));
+	console.log(`Session ${session.id} ready (commit: ${session.repo.commitish})`);
+	console.log(`Asking: ${prompt}\n`);
+
+	const signal = abortImmediate
+		? AbortSignal.abort()
+		: abortMs > 0
+			? AbortSignal.timeout(abortMs)
+			: undefined;
+
+	const stream = session.ask(prompt, signal ? { signal } : undefined);
+
+	if (streamMode) {
+		for await (const event of stream) {
+			process.stdout.write(JSON.stringify(event) + "\n");
+		}
+	} else {
+		const result = await stream.result();
+		process.stdout.write(JSON.stringify(result, null, 2) + "\n");
+	}
+
+	await session.close();
+} catch (err) {
+	process.stdout.write(JSON.stringify(err, Object.getOwnPropertyNames(err as object), 2) + "\n");
+	process.exit(1);
+}

--- a/src/error-classification.ts
+++ b/src/error-classification.ts
@@ -20,7 +20,7 @@ const NETWORK_ERROR_PATTERNS = [
 ];
 
 export interface ClassifiedError {
-	code: ErrorType;
+	errorType: ErrorType;
 	isRetryable: boolean | null;
 }
 
@@ -30,9 +30,9 @@ export interface ClassifiedError {
  */
 export function classifyProviderError(assistantMessage: AssistantMessage, contextWindow?: number): ClassifiedError {
 	if (isContextOverflow(assistantMessage, contextWindow)) {
-		return { code: "context_overflow", isRetryable: true };
+		return { errorType: "context_overflow", isRetryable: true };
 	}
-	return { code: "provider_error", isRetryable: null };
+	return { errorType: "provider_error", isRetryable: null };
 }
 
 /**
@@ -42,20 +42,23 @@ export function classifyProviderError(assistantMessage: AssistantMessage, contex
 export function classifyThrownError(error: unknown): ClassifiedError {
 	const message = error instanceof Error ? error.message : String(error);
 	if (NETWORK_ERROR_PATTERNS.some((p) => p.test(message))) {
-		return { code: "network_error", isRetryable: true };
+		return { errorType: "network_error", isRetryable: true };
 	}
-	return { code: "provider_error", isRetryable: null };
+	return { errorType: "provider_error", isRetryable: null };
 }
 
 /**
  * Derive error source from error code.
  * Library errors originate from megasthenes itself; provider errors from the LLM.
  */
-export function errorSource(code: ErrorType): "provider" | "library" {
-	switch (code) {
+export function errorSource(errorType: ErrorType): "provider" | "library" {
+	switch (errorType) {
 		case "aborted":
 		case "max_iterations":
 		case "internal_error":
+		case "clone_failed":
+		case "invalid_commitish":
+		case "invalid_config":
 			return "library";
 		case "context_overflow":
 		case "provider_error":

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -5,12 +5,12 @@
 import type { ErrorType } from "./types";
 
 export class MegasthenesError extends Error {
-	readonly code: ErrorType;
+	readonly errorType: ErrorType;
 	readonly isRetryable: boolean | null;
 	readonly details?: unknown;
 
 	constructor(
-		code: ErrorType,
+		errorType: ErrorType,
 		message: string,
 		options?: {
 			isRetryable?: boolean | null;
@@ -20,7 +20,7 @@ export class MegasthenesError extends Error {
 	) {
 		super(message, { cause: options?.cause });
 		this.name = "MegasthenesError";
-		this.code = code;
+		this.errorType = errorType;
 		this.isRetryable = options?.isRetryable ?? null;
 		this.details = options?.details;
 	}

--- a/src/forge.ts
+++ b/src/forge.ts
@@ -170,9 +170,13 @@ export async function cleanupWorktree(repo: Repo): Promise<boolean> {
 export async function connectRepo(repoUrl: string, options: ConnectOptions = {}): Promise<Repo> {
 	const forgeName = options.forge ?? inferForge(repoUrl);
 	if (!forgeName) {
-		throw new MegasthenesError("invalid_config", `Cannot infer forge from URL: ${repoUrl}. Please specify 'forge' option.`, {
-			isRetryable: false,
-		});
+		throw new MegasthenesError(
+			"invalid_config",
+			`Cannot infer forge from URL: ${repoUrl}. Please specify 'forge' option.`,
+			{
+				isRetryable: false,
+			},
+		);
 	}
 
 	const forge = forges[forgeName];

--- a/src/forge.ts
+++ b/src/forge.ts
@@ -1,6 +1,7 @@
 import { access, mkdir, rm } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
+import { MegasthenesError } from "./errors";
 
 /**
  * Lock map to prevent race conditions when cloning the same repo in parallel.
@@ -105,7 +106,7 @@ function parseRepoPath(repoUrl: string): { username: string; reponame: string } 
 		.replace(/\.git$/, "")
 		.split("/");
 	if (parts.length < 2 || !parts[0] || !parts[1]) {
-		throw new Error(`Invalid repo URL: ${repoUrl}`);
+		throw new MegasthenesError("invalid_config", `Invalid repo URL: ${repoUrl}`, { isRetryable: false });
 	}
 	return { username: parts[0], reponame: parts[1] };
 }
@@ -169,7 +170,9 @@ export async function cleanupWorktree(repo: Repo): Promise<boolean> {
 export async function connectRepo(repoUrl: string, options: ConnectOptions = {}): Promise<Repo> {
 	const forgeName = options.forge ?? inferForge(repoUrl);
 	if (!forgeName) {
-		throw new Error(`Cannot infer forge from URL: ${repoUrl}. Please specify 'forge' option.`);
+		throw new MegasthenesError("invalid_config", `Cannot infer forge from URL: ${repoUrl}. Please specify 'forge' option.`, {
+			isRetryable: false,
+		});
 	}
 
 	const forge = forges[forgeName];
@@ -205,7 +208,9 @@ export async function connectRepo(repoUrl: string, options: ConnectOptions = {})
 			});
 			const exitCode = await proc.exited;
 			if (exitCode !== 0) {
-				throw new Error(`git clone failed with exit code ${exitCode}`);
+				throw new MegasthenesError("clone_failed", `git clone failed with exit code ${exitCode}`, {
+					isRetryable: true,
+				});
 			}
 		}
 	});
@@ -218,7 +223,9 @@ export async function connectRepo(repoUrl: string, options: ConnectOptions = {})
 	const sha = (await new Response(revParseProc.stdout).text()).trim();
 	const revParseExit = await revParseProc.exited;
 	if (revParseExit !== 0) {
-		throw new Error(`Failed to resolve commitish: ${commitish}`);
+		throw new MegasthenesError("invalid_commitish", `Failed to resolve commitish: ${commitish}`, {
+			isRetryable: false,
+		});
 	}
 
 	const shortSha = sha.slice(0, 12);
@@ -253,7 +260,9 @@ export async function connectRepo(repoUrl: string, options: ConnectOptions = {})
 				cachePath: resolve(cachePath),
 			};
 		}
-		throw new Error(`git worktree add failed with exit code ${worktreeExit}`);
+		throw new MegasthenesError("clone_failed", `git worktree add failed with exit code ${worktreeExit}`, {
+			isRetryable: true,
+		});
 	}
 
 	return {

--- a/src/session.ts
+++ b/src/session.ts
@@ -295,7 +295,7 @@ export class Session {
 
 			// Check for abort before starting
 			if (options?.signal?.aborted) {
-				yield { type: "error", code: "aborted", message: "Aborted", isRetryable: false };
+				yield { type: "error", errorType: "aborted", message: "Aborted", isRetryable: false };
 				return;
 			}
 
@@ -361,7 +361,7 @@ export class Session {
 			for (let iteration = 0; iteration < turnMaxIterations; iteration++) {
 				// Check for abort before each iteration
 				if (options?.signal?.aborted) {
-					yield { type: "error", code: "aborted", message: "Aborted", isRetryable: false };
+					yield { type: "error", errorType: "aborted", message: "Aborted", isRetryable: false };
 					endAskSpanWithError(askSpan, "aborted");
 					askSpanEnded = true;
 					yield {
@@ -441,7 +441,7 @@ export class Session {
 						endGenerationSpanWithError(genSpan, "Empty response from API");
 						yield {
 							type: "error",
-							code: "empty_response",
+							errorType: "empty_response",
 							message: "Model returned an empty response",
 							isRetryable: true,
 						};
@@ -490,7 +490,7 @@ export class Session {
 			// Max iterations reached
 			yield {
 				type: "error",
-				code: "max_iterations",
+				errorType: "max_iterations",
 				message: "Max iterations reached without a final answer.",
 				isRetryable: false,
 			};

--- a/src/stream-processor.ts
+++ b/src/stream-processor.ts
@@ -176,7 +176,7 @@ export function processStreamToEvents(
 						const classified = classifyProviderError(event.error as AssistantMessage, contextWindow);
 						yield {
 							type: "error",
-							code: classified.code,
+							errorType: classified.errorType,
 							message: `API call failed: ${errorText}`,
 							isRetryable: classified.isRetryable,
 							details: event.error,
@@ -202,7 +202,7 @@ export function processStreamToEvents(
 			const classified = classifyThrownError(error);
 			yield {
 				type: "error",
-				code: classified.code,
+				errorType: classified.errorType,
 				message: `API call failed: ${errorMessage}`,
 				isRetryable: classified.isRetryable,
 				details: error,

--- a/src/turn-result-builder.ts
+++ b/src/turn-result-builder.ts
@@ -30,7 +30,7 @@ export class TurnResultBuilder {
 		cacheReadTokens: 0,
 		cacheWriteTokens: 0,
 	};
-	#error: { code: ErrorType; message: string; isRetryable: boolean | null; details?: unknown } | null = null;
+	#error: { errorType: ErrorType; message: string; isRetryable: boolean | null; details?: unknown } | null = null;
 	#startedAt = 0;
 	#endedAt = 0;
 	#metadata: TurnMetadata | null = null;
@@ -134,19 +134,18 @@ export class TurnResultBuilder {
 
 			case "error":
 				this.#error = {
-					code: event.code,
+					errorType: event.errorType,
 					message: event.message,
 					isRetryable: event.isRetryable,
 					details: event.details,
 				};
 				this.#steps.push({
 					type: "error",
-					code: event.code,
-					source: errorSource(event.code),
+					errorType: event.errorType,
+					source: errorSource(event.errorType),
 					message: event.message,
 					isRetryable: event.isRetryable,
 					details: event.details,
-					recoverable: false,
 				});
 				break;
 		}
@@ -158,16 +157,15 @@ export class TurnResultBuilder {
 	}
 
 	/** Set the turn error (called by the session layer). */
-	setError(code: ErrorType, message: string, isRetryable: boolean | null, details?: unknown): void {
-		this.#error = { code, message, isRetryable, details };
+	setError(errorType: ErrorType, message: string, isRetryable: boolean | null, details?: unknown): void {
+		this.#error = { errorType, message, isRetryable, details };
 		this.#steps.push({
 			type: "error",
-			code,
-			source: errorSource(code),
+			errorType,
+			source: errorSource(errorType),
 			message,
 			isRetryable,
 			details,
-			recoverable: false,
 		});
 	}
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,7 +22,10 @@ export type ErrorType =
 	| "provider_error"
 	| "empty_response"
 	| "network_error"
-	| "internal_error";
+	| "internal_error"
+	| "clone_failed"
+	| "invalid_commitish"
+	| "invalid_config";
 
 // =============================================================================
 // Stream Events
@@ -156,8 +159,8 @@ export interface IterationStart {
 /** An unrecoverable error occurred during the turn. */
 export interface TurnError {
 	type: "error";
-	/** Programmatic error code for switch/match. */
-	code: ErrorType;
+	/** Programmatic error type for switch/match. */
+	errorType: ErrorType;
 	/** Human-readable message. */
 	message: string;
 	/** Whether retrying might succeed. null = unknown (e.g., opaque provider errors). */
@@ -208,13 +211,11 @@ export type Step =
 	| { type: "compaction"; summary: string; tokensBefore: number; tokensAfter: number }
 	| {
 			type: "error";
-			code: ErrorType;
+			errorType: ErrorType;
 			source: "provider" | "library";
 			message: string;
 			isRetryable: boolean | null;
 			details?: unknown;
-			/** @deprecated Use code + isRetryable instead. */
-			recoverable: boolean;
 	  };
 
 /** Token usage totals across all iterations in a turn. */
@@ -264,7 +265,7 @@ export interface TurnResult {
 	readonly metadata: TurnMetadata;
 	/** Non-null if the turn ended in an unrecoverable error. */
 	readonly error: {
-		code: ErrorType;
+		errorType: ErrorType;
 		message: string;
 		isRetryable: boolean | null;
 		details?: unknown;

--- a/test/ask-stream.test.ts
+++ b/test/ask-stream.test.ts
@@ -110,7 +110,7 @@ describe("AskStream", () => {
 	test("error stream produces TurnResult with .error set", async () => {
 		const events: StreamEvent[] = [
 			{ type: "turn_start", turnId: "t-1", prompt: "Q", timestamp: 1000 },
-			{ type: "error", code: "provider_error", message: "API failed", isRetryable: null, details: { code: 500 } },
+			{ type: "error", errorType: "provider_error", message: "API failed", isRetryable: null, details: { code: 500 } },
 		];
 		const stream = new AskStreamImpl(makeProducer(events));
 

--- a/test/error-classification.test.ts
+++ b/test/error-classification.test.ts
@@ -24,7 +24,7 @@ describe("classifyProviderError", () => {
 			errorMessage: "prompt is too long: 250000 tokens > 200000 maximum",
 		});
 		const result = classifyProviderError(msg);
-		expect(result.code).toBe("context_overflow");
+		expect(result.errorType).toBe("context_overflow");
 		expect(result.isRetryable).toBe(true);
 	});
 
@@ -33,7 +33,7 @@ describe("classifyProviderError", () => {
 			errorMessage: "This model's maximum context length is 128000 tokens but the request exceeds the context window",
 		});
 		const result = classifyProviderError(msg);
-		expect(result.code).toBe("context_overflow");
+		expect(result.errorType).toBe("context_overflow");
 		expect(result.isRetryable).toBe(true);
 	});
 
@@ -42,14 +42,14 @@ describe("classifyProviderError", () => {
 			errorMessage: "Internal server error",
 		});
 		const result = classifyProviderError(msg);
-		expect(result.code).toBe("provider_error");
+		expect(result.errorType).toBe("provider_error");
 		expect(result.isRetryable).toBeNull();
 	});
 
 	test("returns provider_error when no error message", () => {
 		const msg = makeAssistantMessage({ errorMessage: undefined });
 		const result = classifyProviderError(msg);
-		expect(result.code).toBe("provider_error");
+		expect(result.errorType).toBe("provider_error");
 		expect(result.isRetryable).toBeNull();
 	});
 });
@@ -57,49 +57,49 @@ describe("classifyProviderError", () => {
 describe("classifyThrownError", () => {
 	test("detects ECONNREFUSED as network_error", () => {
 		const result = classifyThrownError(new Error("connect ECONNREFUSED 127.0.0.1:443"));
-		expect(result.code).toBe("network_error");
+		expect(result.errorType).toBe("network_error");
 		expect(result.isRetryable).toBe(true);
 	});
 
 	test("detects fetch failed as network_error", () => {
 		const result = classifyThrownError(new TypeError("fetch failed"));
-		expect(result.code).toBe("network_error");
+		expect(result.errorType).toBe("network_error");
 		expect(result.isRetryable).toBe(true);
 	});
 
 	test("detects ETIMEDOUT as network_error", () => {
 		const result = classifyThrownError(new Error("connect ETIMEDOUT 1.2.3.4:443"));
-		expect(result.code).toBe("network_error");
+		expect(result.errorType).toBe("network_error");
 		expect(result.isRetryable).toBe(true);
 	});
 
 	test("detects ENOTFOUND as network_error", () => {
 		const result = classifyThrownError(new Error("getaddrinfo ENOTFOUND api.example.com"));
-		expect(result.code).toBe("network_error");
+		expect(result.errorType).toBe("network_error");
 		expect(result.isRetryable).toBe(true);
 	});
 
 	test("detects ECONNRESET as network_error", () => {
 		const result = classifyThrownError(new Error("read ECONNRESET"));
-		expect(result.code).toBe("network_error");
+		expect(result.errorType).toBe("network_error");
 		expect(result.isRetryable).toBe(true);
 	});
 
 	test("detects socket hang up as network_error", () => {
 		const result = classifyThrownError(new Error("socket hang up"));
-		expect(result.code).toBe("network_error");
+		expect(result.errorType).toBe("network_error");
 		expect(result.isRetryable).toBe(true);
 	});
 
 	test("returns provider_error for non-network error", () => {
 		const result = classifyThrownError(new Error("Invalid JSON in response"));
-		expect(result.code).toBe("provider_error");
+		expect(result.errorType).toBe("provider_error");
 		expect(result.isRetryable).toBeNull();
 	});
 
 	test("handles non-Error values", () => {
 		const result = classifyThrownError("string error");
-		expect(result.code).toBe("provider_error");
+		expect(result.errorType).toBe("provider_error");
 		expect(result.isRetryable).toBeNull();
 	});
 });
@@ -109,6 +109,9 @@ describe("errorSource", () => {
 		expect(errorSource("aborted")).toBe("library");
 		expect(errorSource("max_iterations")).toBe("library");
 		expect(errorSource("internal_error")).toBe("library");
+		expect(errorSource("clone_failed")).toBe("library");
+		expect(errorSource("invalid_commitish")).toBe("library");
+		expect(errorSource("invalid_config")).toBe("library");
 	});
 
 	test("provider errors", () => {

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -630,19 +630,19 @@ describe("Session", () => {
 		});
 	});
 
-	describe("structured error codes", () => {
-		test("abort yields error with code 'aborted' and isRetryable false", async () => {
+	describe("structured error types", () => {
+		test("abort yields error with errorType 'aborted' and isRetryable false", async () => {
 			const controller = new AbortController();
 			controller.abort();
 
 			const session = new Session(createMockRepo(), createMockConfig());
 			const result = await session.ask("Test", { signal: controller.signal }).result();
 
-			expect(result.error?.code).toBe("aborted");
+			expect(result.error?.errorType).toBe("aborted");
 			expect(result.error?.isRetryable).toBe(false);
 		});
 
-		test("max iterations yields error with code 'max_iterations' and isRetryable false", async () => {
+		test("max iterations yields error with errorType 'max_iterations' and isRetryable false", async () => {
 			const customStream = (() =>
 				createToolCallStreamResult([
 					{ name: "rg", arguments: { pattern: "test" } },
@@ -651,11 +651,11 @@ describe("Session", () => {
 			const session = new Session(createMockRepo(), createMockConfig({ maxIterations: 1, stream: customStream }));
 			const result = await session.ask("Do something").result();
 
-			expect(result.error?.code).toBe("max_iterations");
+			expect(result.error?.errorType).toBe("max_iterations");
 			expect(result.error?.isRetryable).toBe(false);
 		});
 
-		test("provider error yields code 'provider_error'", async () => {
+		test("provider error yields errorType 'provider_error'", async () => {
 			const customStream = (() => ({
 				[Symbol.asyncIterator]: async function* () {
 					yield { type: "error", error: { errorMessage: "API error" } };
@@ -666,11 +666,11 @@ describe("Session", () => {
 			const session = new Session(createMockRepo(), createMockConfig({ stream: customStream }));
 			const result = await session.ask("Test").result();
 
-			expect(result.error?.code).toBe("provider_error");
+			expect(result.error?.errorType).toBe("provider_error");
 			expect(result.error?.isRetryable).toBeNull();
 		});
 
-		test("empty response yields code 'empty_response' and isRetryable true", async () => {
+		test("empty response yields errorType 'empty_response' and isRetryable true", async () => {
 			const customStream = (() => ({
 				[Symbol.asyncIterator]: async function* () {
 					yield { type: "text_delta", delta: "" };
@@ -690,11 +690,11 @@ describe("Session", () => {
 			const session = new Session(createMockRepo(), createMockConfig({ stream: customStream }));
 			const result = await session.ask("Test").result();
 
-			expect(result.error?.code).toBe("empty_response");
+			expect(result.error?.errorType).toBe("empty_response");
 			expect(result.error?.isRetryable).toBe(true);
 		});
 
-		test("error steps include code and source derived from code", async () => {
+		test("error steps include errorType and source derived from errorType", async () => {
 			const controller = new AbortController();
 			controller.abort();
 
@@ -704,7 +704,7 @@ describe("Session", () => {
 			const errorSteps = result.steps.filter((s) => s.type === "error");
 			expect(errorSteps).toHaveLength(1);
 			if (errorSteps[0]?.type === "error") {
-				expect(errorSteps[0].code).toBe("aborted");
+				expect(errorSteps[0].errorType).toBe("aborted");
 				expect(errorSteps[0].source).toBe("library");
 				expect(errorSteps[0].isRetryable).toBe(false);
 			}

--- a/test/turn-result-builder.test.ts
+++ b/test/turn-result-builder.test.ts
@@ -250,7 +250,7 @@ describe("TurnResultBuilder", () => {
 				{ type: "turn_start", turnId: "t-1", prompt: "Q", timestamp: 1000 },
 				{
 					type: "error",
-					code: "provider_error",
+					errorType: "provider_error",
 					message: "API call failed",
 					isRetryable: null,
 					details: { code: 500 },
@@ -258,7 +258,7 @@ describe("TurnResultBuilder", () => {
 			]);
 
 			expect(result.error).not.toBeNull();
-			expect(result.error?.code).toBe("provider_error");
+			expect(result.error?.errorType).toBe("provider_error");
 			expect(result.error?.message).toBe("API call failed");
 			expect(result.error?.isRetryable).toBeNull();
 			expect(result.error?.details).toEqual({ code: 500 });
@@ -267,12 +267,11 @@ describe("TurnResultBuilder", () => {
 			expect(errorSteps).toHaveLength(1);
 			expect(errorSteps[0]).toEqual({
 				type: "error",
-				code: "provider_error",
+				errorType: "provider_error",
 				source: "provider",
 				message: "API call failed",
 				isRetryable: null,
 				details: { code: 500 },
-				recoverable: false,
 			});
 		});
 
@@ -282,7 +281,7 @@ describe("TurnResultBuilder", () => {
 
 			const result = builder.build();
 			expect(result.error).toEqual({
-				code: "max_iterations",
+				errorType: "max_iterations",
 				message: "Max iterations reached",
 				isRetryable: false,
 			});
@@ -290,7 +289,7 @@ describe("TurnResultBuilder", () => {
 			const errorSteps = result.steps.filter((s) => s.type === "error");
 			expect(errorSteps).toHaveLength(1);
 			if (errorSteps[0]?.type === "error") {
-				expect(errorSteps[0].code).toBe("max_iterations");
+				expect(errorSteps[0].errorType).toBe("max_iterations");
 				expect(errorSteps[0].source).toBe("library");
 			}
 		});
@@ -298,7 +297,7 @@ describe("TurnResultBuilder", () => {
 		test("error with preceding text preserves both as steps", () => {
 			const result = buildFromEvents([
 				{ type: "text", text: "partial" },
-				{ type: "error", code: "provider_error", message: "interrupted", isRetryable: null },
+				{ type: "error", errorType: "provider_error", message: "interrupted", isRetryable: null },
 			]);
 
 			expect(result.steps).toHaveLength(2);

--- a/test/turns-to-messages.test.ts
+++ b/test/turns-to-messages.test.ts
@@ -239,11 +239,10 @@ describe("reconstructContext", () => {
 				{ type: "text", text: "Answer.", role: "assistant" },
 				{
 					type: "error",
-					code: "provider_error",
+					errorType: "provider_error",
 					source: "provider",
 					message: "Rate limited",
 					isRetryable: null,
-					recoverable: true,
 				},
 			],
 		});


### PR DESCRIPTION
Breaking changes to the error API surface:
- Rename `code` field to `errorType` on TurnError, Step error variant, TurnResult.error, MegasthenesError, and ClassifiedError — "code" was misleading since the values are descriptive strings, not numbers.
- Remove deprecated `recoverable` field from the Step error variant.
- Add structured MegasthenesError throws for connect-time failures in forge.ts (clone_failed, invalid_commitish, invalid_config) so all library errors carry errorType + isRetryable.
- Add test-ask.ts CLI script for manual API testing with JSON output.