### PR TITLE
fix(tracing): align errors and trace connect flow

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.4.8/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.4.10/schema.json",
 	"files": {
 		"includes": [
 			"**",

--- a/docs/src/content/docs/guides/configuration.md
+++ b/docs/src/content/docs/guides/configuration.md
@@ -191,8 +191,13 @@ To send traces to any OTel-compatible backend (Jaeger, Honeycomb, Langfuse, etc.
 2. Create and start a `NodeSDK` instance **before** creating any `Client`
 3. All `session.ask()` calls will automatically emit spans to your backend
 
-Tracing currently covers the `session.ask()` execution path. The spans emitted today are:
+Tracing currently covers the connected session lifecycle. The main spans emitted today are:
 - `ask`
+- `connect`
+- `repo.clone_or_fetch`
+- `repo.resolve_commitish`
+- `repo.create_worktree`
+- `ask.turn`
 - `compaction`
 - `gen_ai.chat`
 - `gen_ai.execute_tool`

--- a/docs/src/content/docs/guides/configuration.md
+++ b/docs/src/content/docs/guides/configuration.md
@@ -5,133 +5,53 @@ sidebar:
   order: 2
 ---
 
-megasthenes uses a two-tier configuration model:
+### Connect Options
 
-- **`ClientConfig`** — shared infrastructure (sandbox, logging). Passed to the `Client` constructor.
-- **`SessionConfig`** — behavioral settings (model, repo, thinking, compaction). Passed to `client.connect()`.
-
-This separation lets you create one client and connect to multiple repositories with different models and settings.
-
-### Client Configuration
-
-The `Client` constructor accepts optional infrastructure config:
-
-```ts
-import { Client, consoleLogger, nullLogger } from "@nilenso/megasthenes";
-
-// Defaults: no sandbox, console logging
-const client = new Client();
-
-// With custom logging
-const client = new Client({ logger: nullLogger });
-
-// With sandbox mode
-const client = new Client({
-  sandbox: {
-    baseUrl: "http://localhost:8080",
-    timeoutMs: 120_000,
-    secret: "optional-auth-secret",
-  },
-});
-```
-
-See the [Sandboxed Execution guide](/megasthenes/guides/sandbox/) for details on running the sandbox server.
-
-### Logging
-
-```ts
-import {
-  Client,
-  consoleLogger,
-  nullLogger,
-  type Logger,
-} from "@nilenso/megasthenes";
-
-// Console logger (default)
-const client = new Client({ logger: consoleLogger });
-
-// Silence all logging
-const client = new Client({ logger: nullLogger });
-
-// Custom logger
-const customLogger: Logger = {
-  error: (label, error) => myLogSystem.error(label, error),
-  warn: (label, content) => myLogSystem.warn(`${label}: ${content}`),
-  log: (label, content) => myLogSystem.info(`${label}: ${content}`),
-  info: (label, content) => myLogSystem.info(`${label}: ${content}`),
-  debug: (label, content) => myLogSystem.debug(`${label}: ${content}`),
-};
-const client = new Client({ logger: customLogger });
-```
-
-### Session Configuration
-
-All behavioral config is passed to `client.connect()`:
-
-```ts
-const session = await client.connect({
-  repo: { url: "https://github.com/owner/repo" },
-  model: { provider: "anthropic", id: "claude-sonnet-4-6" },
-  maxIterations: 20,
-});
-```
-
-### Repository Options
+The `connect()` method accepts git-related options:
 
 ```ts
 // Connect to a specific commit, branch, or tag
-const session = await client.connect({
-  repo: { url: "https://github.com/owner/repo", commitish: "v1.0.0" },
-  model: { provider: "anthropic", id: "claude-sonnet-4-6" },
-  maxIterations: 20,
+const session = await client.connect("https://github.com/owner/repo", {
+  commitish: "v1.0.0",
 });
 
-// Private repository with a token
-const session = await client.connect({
-  repo: {
-    url: "https://github.com/owner/repo",
-    token: process.env.GITHUB_TOKEN,
-  },
-  model: { provider: "anthropic", id: "claude-sonnet-4-6" },
-  maxIterations: 20,
+// Connect to a private repository with a token
+const session = await client.connect("https://github.com/owner/repo", {
+  token: process.env.GITHUB_TOKEN,
 });
 
-// Self-hosted GitLab (forge auto-detected for github.com and gitlab.com)
-const session = await client.connect({
-  repo: {
-    url: "https://gitlab.example.com/owner/repo",
-    forge: "gitlab",
-    token: process.env.GITLAB_TOKEN,
-  },
-  model: { provider: "anthropic", id: "claude-sonnet-4-6" },
-  maxIterations: 20,
+// Explicitly specify the forge (auto-detected for github.com and gitlab.com)
+const session = await client.connect("https://gitlab.example.com/owner/repo", {
+  forge: "gitlab",
+  token: process.env.GITLAB_TOKEN,
 });
 ```
 
 ### Model and Provider
 
-The `model` field in `SessionConfig` requires both a `provider` and an `id`. Available providers and model IDs are defined in [`@mariozechner/pi-ai`](https://github.com/badlogic/pi-mono/blob/main/packages/pi-ai/src/models.generated.ts). The corresponding API key environment variable is resolved automatically (e.g. `OPENROUTER_API_KEY`, `ANTHROPIC_API_KEY`).
+The `Client` accepts a `ForgeConfig` object that controls the AI model and behavior.
+
+By default, the client uses **OpenRouter** with **`anthropic/claude-sonnet-4.6`**. You can override both `provider` and `model` (they must be specified together). The corresponding API key environment variable is resolved automatically (e.g. `OPENROUTER_API_KEY`, `ANTHROPIC_API_KEY`).
+
+Available providers and model IDs are defined in [`@mariozechner/pi-ai`](https://github.com/badlogic/pi-mono/blob/main/packages/pi-ai/src/models.generated.ts).
 
 ```ts
-// OpenRouter
-const session = await client.connect({
-  repo: { url: "https://github.com/owner/repo" },
-  model: { provider: "openrouter", id: "anthropic/claude-sonnet-4-6" },
-  maxIterations: 20,
+import { Client, type ForgeConfig } from "@nilenso/megasthenes";
+
+// Use defaults (openrouter + anthropic/claude-sonnet-4.6)
+const client = new Client();
+
+// Or specify a different provider/model
+const client = new Client({
+  provider: "anthropic",
+  model: "claude-sonnet-4.6",
 });
 
-// Anthropic direct
-const session = await client.connect({
-  repo: { url: "https://github.com/owner/repo" },
-  model: { provider: "anthropic", id: "claude-sonnet-4-6" },
-  maxIterations: 20,
-});
-
-// Google
-const session = await client.connect({
-  repo: { url: "https://github.com/owner/repo" },
-  model: { provider: "google", id: "gemini-2.5-pro" },
-  maxIterations: 20,
+// Full configuration
+const client = new Client({
+  provider: "openrouter",
+  model: "anthropic/claude-sonnet-4.6",
+  maxIterations: 10,                    // Optional: default is 20
 });
 ```
 
@@ -140,11 +60,8 @@ const session = await client.connect({
 By default, megasthenes builds a system prompt that includes the repository URL and commit SHA. You can override it to customize the assistant's behavior:
 
 ```ts
-const session = await client.connect({
-  repo: { url: "https://github.com/owner/repo" },
-  model: { provider: "anthropic", id: "claude-sonnet-4-6" },
-  maxIterations: 20,
-  systemPrompt: "You are a security auditor. Focus on identifying vulnerabilities.",
+const client = new Client({
+  systemPrompt: "You are a security auditor. Focus on identifying vulnerabilities, insecure patterns, and potential attack vectors in the codebase.",
 });
 ```
 
@@ -154,13 +71,54 @@ You can also build the default prompt yourself and extend it:
 import { Client, buildDefaultSystemPrompt } from "@nilenso/megasthenes";
 
 const base = buildDefaultSystemPrompt("https://github.com/owner/repo", "abc123");
-const session = await client.connect({
-  repo: { url: "https://github.com/owner/repo" },
-  model: { provider: "anthropic", id: "claude-sonnet-4-6" },
-  maxIterations: 20,
+const client = new Client({
   systemPrompt: `${base}\n\nAlways respond in Spanish.`,
 });
 ```
+
+### Logging
+
+The second parameter to the constructor controls logging:
+
+```ts
+import {
+  Client,
+  consoleLogger,
+  nullLogger,
+  type Logger,
+} from "@nilenso/megasthenes";
+
+// Use console logger (default)
+const client = new Client(config, consoleLogger);
+
+// Silence all logging
+const client = new Client(config, nullLogger);
+
+// Custom logger
+const customLogger: Logger = {
+  log: (label, content) => myLogSystem.info(`${label}: ${content}`),
+  error: (label, error) => myLogSystem.error(label, error),
+};
+const client = new Client(config, customLogger);
+```
+
+### Sandboxing
+
+For production deployments or untrusted repositories, enable sandbox mode to run all operations in an isolated container:
+
+```ts
+const client = new Client({
+  sandbox: {
+    baseUrl: "http://localhost:8080",
+    timeoutMs: 120_000,
+    secret: "optional-auth-secret",
+  },
+});
+```
+
+When enabled, repository cloning and all tool execution (file reads, searches, git operations) happen inside the sandbox. The host filesystem is never accessed directly.
+
+See the [Sandboxed Execution guide](/megasthenes/guides/sandbox/) for security layers, architecture, and how to run the sandbox server.
 
 ### Thinking
 
@@ -171,38 +129,35 @@ Control the model's reasoning/thinking behavior via the `thinking` field. Megast
 
 ```ts
 // OpenAI — effort-based reasoning
-const session = await client.connect({
-  repo: { url: "https://github.com/owner/repo" },
-  model: { provider: "openai", id: "o3" },
-  maxIterations: 20,
+const client = new Client({
+  provider: "openai",
+  model: "o3",
   thinking: { effort: "low" },
 });
 
-// Anthropic 4.5 — effort-based
-const session = await client.connect({
-  repo: { url: "https://github.com/owner/repo" },
-  model: { provider: "anthropic", id: "claude-sonnet-4-5-20251022" },
-  maxIterations: 20,
+// Anthropic 4.5 — effort-based (older model, no adaptive support)
+const client = new Client({
+  provider: "anthropic",
+  model: "claude-sonnet-4-5-20251022",
   thinking: { effort: "high", budgetOverrides: { high: 10000 } },
 });
 
 // Anthropic 4.6 — adaptive (model decides when/how much to think)
-const session = await client.connect({
-  repo: { url: "https://github.com/owner/repo" },
-  model: { provider: "anthropic", id: "claude-sonnet-4-6" },
-  maxIterations: 20,
+const client = new Client({
+  provider: "anthropic",
+  model: "claude-sonnet-4-6",
   thinking: { type: "adaptive" },
 });
 
 // Anthropic 4.6 — adaptive with explicit effort guidance
-const session = await client.connect({
-  repo: { url: "https://github.com/owner/repo" },
-  model: { provider: "anthropic", id: "claude-sonnet-4-6" },
-  maxIterations: 20,
+const client = new Client({
+  provider: "anthropic",
+  model: "claude-sonnet-4-6",
   thinking: { type: "adaptive", effort: "medium" },
 });
 
-// No thinking (default — omit the thinking field)
+// No thinking (default)
+const client = new Client();
 ```
 
 | Field | Type | Description |
@@ -216,15 +171,12 @@ const session = await client.connect({
 When conversations grow long, megasthenes can automatically summarize older messages to stay within the model's context window. This is enabled by default.
 
 ```ts
-const session = await client.connect({
-  repo: { url: "https://github.com/owner/repo" },
-  model: { provider: "anthropic", id: "claude-sonnet-4-6" },
-  maxIterations: 20,
+const client = new Client({
   compaction: {
     enabled: true,            // default: true
     contextWindow: 200_000,   // default: 200K tokens
-    reserveTokens: 16_384,    // default: 16K — tokens reserved for the response
-    keepRecentTokens: 20_000, // default: 20K — recent messages to keep unsummarized
+    reserveTokens: 16_384,    // tokens reserved for the response
+    keepRecentTokens: 20_000, // recent messages to keep unsummarized
   },
 });
 ```
@@ -238,6 +190,12 @@ To send traces to any OTel-compatible backend (Jaeger, Honeycomb, Langfuse, etc.
 1. Install `@opentelemetry/sdk-node` and your backend's exporter or span processor
 2. Create and start a `NodeSDK` instance **before** creating any `Client`
 3. All `session.ask()` calls will automatically emit spans to your backend
+
+Tracing currently covers the `session.ask()` execution path. The spans emitted today are:
+- `ask`
+- `compaction`
+- `gen_ai.chat`
+- `gen_ai.execute_tool`
 
 #### Console (development)
 
@@ -261,27 +219,23 @@ const sdk = new NodeSDK({
 sdk.start();
 ```
 
-See the [Observability guide](/megasthenes/guides/observability/) for the full trace structure and captured attributes.
+See the [Observability guide](/megasthenes/guides/observability/) for the full span hierarchy, emitted attributes/events, and structured error tracing.
 
-### Streaming
+### Streaming Progress
 
-`session.ask()` returns an `AskStream` — an async iterable of `StreamEvent` objects. Consume events in real time or await the final result:
+Use the `onProgress` callback to receive real-time events during inference:
 
 ```ts
-const stream = session.ask("Find all API endpoints");
-
-for await (const event of stream) {
-  switch (event.type) {
-    case "tool_use_start":
-      console.log(`Using tool: ${event.name}`);
-      break;
-    case "text_delta":
-      process.stdout.write(event.delta);
-      break;
-  }
-}
-
-const result = await stream.result();
+const result = await session.ask("Find all API endpoints", {
+  onProgress: (event) => {
+    switch (event.type) {
+      case "tool_call":
+        console.log(`Using tool: ${event.name}`);
+        break;
+      case "text_delta":
+        process.stdout.write(event.text);
+        break;
+    }
+  },
+});
 ```
-
-See the [Streaming guide](/megasthenes/guides/streaming/) for the full event type reference and advanced patterns.

--- a/docs/src/content/docs/guides/observability.md
+++ b/docs/src/content/docs/guides/observability.md
@@ -2,14 +2,16 @@
 title: Observability
 description: Monitor megasthenes sessions with OpenTelemetry tracing.
 sidebar:
-  order: 6
+  order: 4
 ---
 
-megasthenes instruments all LLM interactions with [OpenTelemetry](https://opentelemetry.io/) spans following the [GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/).
+megasthenes instruments `session.ask()` with [OpenTelemetry](https://opentelemetry.io/) spans using the [GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/), plus a small set of `megasthenes.*` attributes for repository- and agent-specific details.
 
-### Setup
+The library depends only on `@opentelemetry/api`. If your application does not install and register an OTel SDK, tracing is a no-op.
 
-Install the OpenTelemetry SDK and configure a tracer provider before creating sessions:
+## Setup
+
+Install the OpenTelemetry SDK and configure a tracer provider **before** creating any sessions:
 
 ```ts
 import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
@@ -17,88 +19,191 @@ import { SimpleSpanProcessor } from "@opentelemetry/sdk-trace-base";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
 
 const provider = new NodeTracerProvider();
-provider.addSpanProcessor(
-  new SimpleSpanProcessor(new OTLPTraceExporter())
-);
+provider.addSpanProcessor(new SimpleSpanProcessor(new OTLPTraceExporter()));
 provider.register();
 ```
 
-Once registered, all `session.ask()` calls automatically emit spans.
+Once registered, every `session.ask()` call automatically emits spans.
 
-### Trace Structure
+## Trace structure
 
-```
-megasthenes.session.ask
-├── megasthenes.compaction (if context was compacted)
-├── gen_ai.chat (per LLM iteration)
-│   └── gen_ai.execute_tool (per tool invocation)
+A traced turn currently looks like this:
+
+```text
+ask
+├── compaction
 ├── gen_ai.chat
+│   ├── gen_ai.execute_tool
 │   └── gen_ai.execute_tool
-└── ...
+├── gen_ai.chat
+└── gen_ai.chat
 ```
 
-### Captured Attributes
+- `ask`: root span for one `session.ask()` call
+- `compaction`: emitted once per turn, even if no compaction happens
+- `gen_ai.chat`: one span per LLM iteration
+- `gen_ai.execute_tool`: one span per tool execution
 
-#### Ask span (`megasthenes.session.ask`)
+## Span reference
 
-| Attribute | Description |
+### `ask`
+
+Root span for a single `session.ask()` call.
+
+**Always includes**
+- `gen_ai.operation.name = "chat"`
+- `gen_ai.request.model`
+- `megasthenes.session.id`
+- `megasthenes.repo.url`
+- `megasthenes.repo.commitish`
+
+**Events**
+- `gen_ai.system_instructions`
+- `gen_ai.input.messages`
+
+**On successful completion**
+- `gen_ai.usage.input_tokens`
+- `gen_ai.usage.output_tokens`
+- `megasthenes.total_iterations`
+- `megasthenes.total_tool_calls`
+
+Use this span for turn-level latency, token totals, iteration counts, and overall success/failure.
+
+### `compaction`
+
+Child span covering context compaction before the turn's first generation call.
+
+**Attributes**
+- `megasthenes.compaction.was_compacted`
+- `megasthenes.compaction.tokens_before` when compaction happens
+- `megasthenes.compaction.tokens_after` when compaction happens
+
+This span is emitted even when compaction is skipped, so you can measure how often compaction is considered vs. actually triggered.
+
+### `gen_ai.chat`
+
+Child span for one LLM inference iteration.
+
+**Attributes**
+- `gen_ai.operation.name = "chat"`
+- `gen_ai.request.model`
+- `gen_ai.provider.name`
+- `megasthenes.iteration`
+- `gen_ai.response.finish_reason` when available
+- `gen_ai.usage.input_tokens`
+- `gen_ai.usage.output_tokens`
+- `gen_ai.usage.cache_read.input_tokens`
+- `gen_ai.usage.cache_creation.input_tokens`
+
+**Events**
+- `gen_ai.input.messages`
+- `gen_ai.output.messages`
+
+Use these spans to inspect per-iteration prompts, responses, stop reasons, and token usage.
+
+### `gen_ai.execute_tool`
+
+Child span for one tool invocation made by the model.
+
+**Attributes**
+- `gen_ai.operation.name = "execute_tool"`
+- `gen_ai.tool.name`
+- `gen_ai.tool.call.id`
+
+**Events**
+- `gen_ai.tool.call.arguments`
+- `gen_ai.tool.call.result`
+
+Use these spans to measure tool latency and inspect tool arguments/results.
+
+## Error spans
+
+When a span fails, megasthenes records both standard span status and structured error attributes.
+
+**Common error attributes**
+- `error.type`
+- `megasthenes.error.stage`
+- `megasthenes.error.name`
+- `megasthenes.error.message`
+
+**Stages**
+- `ask`
+- `generation`
+- `compaction`
+- `tool_execution`
+
+`error.type` is aligned with the public API's `ErrorType` values where applicable, so trace queries and programmatic SDK errors use the same vocabulary.
+
+### Error types you may see
+
+| `error.type` | Meaning |
 |---|---|
-| `gen_ai.operation.name` | `"chat"` |
-| `gen_ai.request.model` | Model identifier |
-| `megasthenes.session.id` | Unique session ID |
-| `megasthenes.repo.url` | Repository URL |
-| `megasthenes.repo.commitish` | Resolved commit SHA |
-| `gen_ai.usage.input_tokens` | Total prompt tokens |
-| `gen_ai.usage.output_tokens` | Total completion tokens |
-| `megasthenes.total_iterations` | Number of LLM iterations in the turn |
-| `megasthenes.total_tool_calls` | Total tool invocations in the turn |
+| `aborted` | The turn was aborted after tracing had started |
+| `max_iterations` | The turn exhausted its tool-use / generation loop budget |
+| `context_overflow` | The provider rejected the prompt because it exceeded the context window |
+| `provider_error` | The provider returned a non-specific API error |
+| `empty_response` | The model returned no final text content |
+| `network_error` | A thrown network-level failure occurred during generation |
+| `internal_error` | megasthenes hit an internal failure, or a tool/compaction span failed |
 
-#### Generation span (`gen_ai.chat`)
+### Typical error shapes
 
-| Attribute | Description |
-|---|---|
-| `gen_ai.operation.name` | `"chat"` |
-| `gen_ai.request.model` | Model identifier |
-| `gen_ai.provider.name` | Provider name |
-| `megasthenes.iteration` | Zero-based iteration index |
-| `gen_ai.usage.input_tokens` | Prompt tokens for this iteration |
-| `gen_ai.usage.output_tokens` | Completion tokens for this iteration |
-| `gen_ai.usage.cache_read.input_tokens` | Prompt cache hits |
-| `gen_ai.usage.cache_creation.input_tokens` | Prompt cache writes |
-| `gen_ai.response.finish_reason` | Why the model stopped |
+**Provider failure**
+- `gen_ai.chat`: `error.type = provider_error`, `megasthenes.error.stage = generation`
+- `ask`: `error.type = provider_error`, `megasthenes.error.stage = ask`
 
-#### Tool span (`gen_ai.execute_tool`)
+**Context overflow**
+- `gen_ai.chat`: `error.type = context_overflow`
+- `ask`: `error.type = context_overflow`
 
-| Attribute | Description |
-|---|---|
-| `gen_ai.operation.name` | `"execute_tool"` |
-| `gen_ai.tool.name` | Tool name (`rg`, `fd`, `read`, `ls`, `git`) |
-| `gen_ai.tool.call.id` | Unique tool call ID |
+**Network failure**
+- `gen_ai.chat`: `error.type = network_error`
+- `ask`: `error.type = network_error`
 
-#### Compaction span
+**Empty final response**
+- `gen_ai.chat`: `error.type = empty_response`
+- `ask`: `error.type = empty_response`
 
-| Attribute | Description |
-|---|---|
-| `megasthenes.compaction.was_compacted` | Whether compaction occurred |
-| `megasthenes.compaction.tokens_before` | Token count before compaction |
-| `megasthenes.compaction.tokens_after` | Token count after compaction |
+**Tool failure that the model recovers from**
+- `gen_ai.execute_tool`: `error.type = internal_error`, `megasthenes.error.stage = tool_execution`
+- later `ask` / `gen_ai.chat` spans may still finish successfully if the model continues
 
-#### Error attributes
+**Compaction failure**
+- `compaction`: `error.type = internal_error`, `megasthenes.error.stage = compaction`
+- the turn may still continue successfully
 
-| Attribute | Description |
-|---|---|
-| `error.type` | Standard OTel error type |
-| `megasthenes.error.name` | Error name |
-| `megasthenes.error.message` | Error message |
+## Example failing trace
 
-### OTel Events
+A provider failure typically looks like:
 
-The library also emits OTel events on spans following GenAI conventions:
+```text
+ask [ERROR]
+├── compaction [OK]
+└── gen_ai.chat [ERROR]
+```
 
-| Event | Description |
-|---|---|
-| `gen_ai.system_instructions` | System prompt content |
-| `gen_ai.input.messages` | Input messages to the model |
-| `gen_ai.output.messages` | Output messages from the model |
-| `gen_ai.tool.call.arguments` | Tool call argument JSON |
-| `gen_ai.tool.call.result` | Tool execution result |
+A tool failure that the model recovers from may look like:
+
+```text
+ask [OK]
+├── compaction [OK]
+├── gen_ai.chat [OK]
+│   └── gen_ai.execute_tool [ERROR]
+└── gen_ai.chat [OK]
+```
+
+## What is currently traced
+
+Today, tracing covers the runtime `ask()` path:
+- root ask span
+- compaction
+- per-iteration generation
+- per-tool execution
+
+## Current limitations
+
+The following flows are **not** currently traced:
+- repository connect / clone / worktree setup
+- pre-start aborts that happen before the `ask` span is created
+
+If you need visibility into connection/setup failures, add application-level spans around `client.connect(...)` until megasthenes exposes those directly.

--- a/docs/src/content/docs/guides/observability.md
+++ b/docs/src/content/docs/guides/observability.md
@@ -5,7 +5,7 @@ sidebar:
   order: 4
 ---
 
-megasthenes instruments `session.ask()` with [OpenTelemetry](https://opentelemetry.io/) spans using the [GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/), plus a small set of `megasthenes.*` attributes for repository- and agent-specific details.
+megasthenes instruments session setup and turns with [OpenTelemetry](https://opentelemetry.io/) spans using the [GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/), plus a small set of `megasthenes.*` attributes for repository- and agent-specific details.
 
 The library depends only on `@opentelemetry/api`. If your application does not install and register an OTel SDK, tracing is a no-op.
 
@@ -23,23 +23,32 @@ provider.addSpanProcessor(new SimpleSpanProcessor(new OTLPTraceExporter()));
 provider.register();
 ```
 
-Once registered, every `session.ask()` call automatically emits spans.
+Once registered, `client.connect(...)` and later `session.ask()` calls automatically emit spans.
 
 ## Trace structure
 
-A traced turn currently looks like this:
+A traced session currently looks like this:
 
 ```text
 ask
-├── compaction
-├── gen_ai.chat
-│   ├── gen_ai.execute_tool
-│   └── gen_ai.execute_tool
-├── gen_ai.chat
-└── gen_ai.chat
+├── connect
+│   ├── repo.clone_or_fetch
+│   ├── repo.resolve_commitish
+│   └── repo.create_worktree
+├── ask.turn
+│   ├── compaction
+│   ├── gen_ai.chat
+│   │   └── gen_ai.execute_tool
+│   └── gen_ai.chat
+└── ask.turn
 ```
 
-- `ask`: root span for one `session.ask()` call
+- `ask`: long-lived root span for one connected session
+- `connect`: repository setup for that session
+- `repo.clone_or_fetch`: local bare clone / fetch / cache reuse
+- `repo.resolve_commitish`: commit resolution via `git rev-parse`
+- `repo.create_worktree`: worktree creation or reuse
+- `ask.turn`: one span per `session.ask()` call
 - `compaction`: emitted once per turn, even if no compaction happens
 - `gen_ai.chat`: one span per LLM iteration
 - `gen_ai.execute_tool`: one span per tool execution
@@ -48,7 +57,41 @@ ask
 
 ### `ask`
 
-Root span for a single `session.ask()` call.
+Long-lived root span for a connected session.
+
+**Always includes**
+- `megasthenes.repo.url`
+- `megasthenes.repo.requested_commitish`
+- `megasthenes.connect.mode`
+- `megasthenes.session.id` once the session has been created
+- `megasthenes.repo.commitish` once the repo has been resolved
+
+Use this span for end-to-end session duration and to correlate setup and later turns in one trace.
+
+### `connect`
+
+Child span for repository setup during `client.connect(...)`.
+
+This span is where local clone/fetch/worktree work or sandbox clone work is recorded.
+
+### `repo.clone_or_fetch`
+
+Local child span covering:
+- cache hit / cache reuse
+- `git fetch` when the requested commitish is missing locally
+- fresh `git clone --bare --filter=blob:none`
+
+### `repo.resolve_commitish`
+
+Local child span covering `git rev-parse` for the requested commitish.
+
+### `repo.create_worktree`
+
+Local child span covering worktree reuse or `git worktree add`.
+
+### `ask.turn`
+
+Child span for a single `session.ask()` call.
 
 **Always includes**
 - `gen_ai.operation.name = "chat"`
@@ -128,6 +171,7 @@ When a span fails, megasthenes records both standard span status and structured 
 
 **Stages**
 - `ask`
+- `connect`
 - `generation`
 - `compaction`
 - `tool_execution`
@@ -174,36 +218,41 @@ When a span fails, megasthenes records both standard span status and structured 
 
 ## Example failing trace
 
-A provider failure typically looks like:
+A provider failure in one turn typically looks like:
 
 ```text
-ask [ERROR]
-├── compaction [OK]
-└── gen_ai.chat [ERROR]
+ask [OK]
+├── connect [OK]
+└── ask.turn [ERROR]
+    ├── compaction [OK]
+    └── gen_ai.chat [ERROR]
 ```
 
 A tool failure that the model recovers from may look like:
 
 ```text
 ask [OK]
-├── compaction [OK]
-├── gen_ai.chat [OK]
-│   └── gen_ai.execute_tool [ERROR]
-└── gen_ai.chat [OK]
+├── connect [OK]
+└── ask.turn [OK]
+    ├── compaction [OK]
+    ├── gen_ai.chat [OK]
+    │   └── gen_ai.execute_tool [ERROR]
+    └── gen_ai.chat [OK]
 ```
 
 ## What is currently traced
 
-Today, tracing covers the runtime `ask()` path:
-- root ask span
+Today, tracing covers the connected session lifecycle:
+- root `ask` session span
+- `connect`
+- local clone/fetch/rev-parse/worktree spans
+- per-turn `ask.turn`
 - compaction
 - per-iteration generation
 - per-tool execution
 
 ## Current limitations
 
-The following flows are **not** currently traced:
-- repository connect / clone / worktree setup
-- pre-start aborts that happen before the `ask` span is created
-
-If you need visibility into connection/setup failures, add application-level spans around `client.connect(...)` until megasthenes exposes those directly.
+The following flows still have gaps:
+- sandbox clone tracing is present, but other sandbox lifecycle operations are still less detailed than local git setup
+- a turn aborted before its `ask.turn` span starts will not produce a turn span, though the session root span still exists

--- a/scripts/eval/eval-viewer.html
+++ b/scripts/eval/eval-viewer.html
@@ -2571,7 +2571,7 @@ async function submitKey(key) {
 
 async function runAnalysis(key) {
   const cr = state.comparison.find(c => c.key === key);
-  if (!cr || !cr.runA || !cr.runB) return;
+  if (!cr?.runA || !cr.runB) return;
 
   const cacheKey = `${cr.key}|${cr.runA.sessionId}:${cr.runB.sessionId}`;
   const btn = $('analyseBtn');

--- a/src/error-classification.ts
+++ b/src/error-classification.ts
@@ -57,6 +57,7 @@ export function errorSource(errorType: ErrorType): "provider" | "library" {
 		case "max_iterations":
 		case "internal_error":
 		case "clone_failed":
+		case "fetch_failed":
 		case "invalid_commitish":
 		case "invalid_config":
 			return "library";

--- a/src/forge.ts
+++ b/src/forge.ts
@@ -201,7 +201,12 @@ export async function connectRepo(repoUrl: string, options: ConnectOptions = {},
 						stdout: "inherit",
 						stderr: "inherit",
 					});
-					await proc.exited;
+					const fetchExit = await proc.exited;
+					if (fetchExit !== 0) {
+						throw new MegasthenesError("fetch_failed", `git fetch failed with exit code ${fetchExit}`, {
+							isRetryable: true,
+						});
+					}
 					span?.addEvent("repo.fetch.finished");
 					endChildSpan(span, {
 						"megasthenes.repo.cache_path": cachePath,

--- a/src/forge.ts
+++ b/src/forge.ts
@@ -202,7 +202,7 @@ export async function connectRepo(repoUrl: string, options: ConnectOptions = {},
 						stderr: "inherit",
 					});
 					await proc.exited;
-					span?.addEvent("repo.fetch.started");
+					span?.addEvent("repo.fetch.finished");
 					endChildSpan(span, {
 						"megasthenes.repo.cache_path": cachePath,
 						"megasthenes.repo.cache_exists": true,

--- a/src/forge.ts
+++ b/src/forge.ts
@@ -269,41 +269,35 @@ export async function connectRepo(repoUrl: string, options: ConnectOptions = {},
 	const shortSha = sha.slice(0, 12);
 	const worktreePath = resolve(basePath, "trees", shortSha);
 	return withChildSpan(parentSpan, "repo.create_worktree", "clone_failed", async (span) => {
-		const makeRepo = (reused: boolean): Repo => {
-			endChildSpan(span, {
-				"megasthenes.repo.worktree_path": worktreePath,
-				"megasthenes.connect.worktree_reused": reused,
+		let reused = await exists(worktreePath);
+		if (!reused) {
+			await mkdir(resolve(basePath, "trees"), { recursive: true });
+			const worktreeProc = Bun.spawn(["git", "worktree", "add", worktreePath, sha], {
+				cwd: cachePath,
+				stdout: "pipe",
+				stderr: "pipe",
 			});
-			return {
-				url: repoUrl,
-				localPath: worktreePath,
-				forge,
-				commitish: sha,
-				cachePath: resolve(cachePath),
-			};
-		};
-
-		if (await exists(worktreePath)) {
-			return makeRepo(true);
-		}
-
-		await mkdir(resolve(basePath, "trees"), { recursive: true });
-		const worktreeProc = Bun.spawn(["git", "worktree", "add", worktreePath, sha], {
-			cwd: cachePath,
-			stdout: "pipe",
-			stderr: "pipe",
-		});
-		const worktreeExit = await worktreeProc.exited;
-		if (worktreeExit !== 0) {
-			// Another concurrent call may have created the worktree between our exists()
-			// check and the worktree add. If so, just return it.
-			if (await exists(worktreePath)) {
-				return makeRepo(true);
+			const worktreeExit = await worktreeProc.exited;
+			// If `git worktree add` failed, it may be because a concurrent call won the race.
+			// Re-check the path: if still missing, it's a real failure.
+			if (worktreeExit !== 0 && !(await exists(worktreePath))) {
+				throw new MegasthenesError("clone_failed", `git worktree add failed with exit code ${worktreeExit}`, {
+					isRetryable: true,
+				});
 			}
-			throw new MegasthenesError("clone_failed", `git worktree add failed with exit code ${worktreeExit}`, {
-				isRetryable: true,
-			});
+			reused = worktreeExit !== 0;
 		}
-		return makeRepo(false);
+
+		endChildSpan(span, {
+			"megasthenes.repo.worktree_path": worktreePath,
+			"megasthenes.connect.worktree_reused": reused,
+		});
+		return {
+			url: repoUrl,
+			localPath: worktreePath,
+			forge,
+			commitish: sha,
+			cachePath: resolve(cachePath),
+		};
 	});
 }

--- a/src/forge.ts
+++ b/src/forge.ts
@@ -1,7 +1,19 @@
 import { access, mkdir, rm } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
+import type { Span } from "@opentelemetry/api";
 import { MegasthenesError } from "./errors";
+import {
+	endCloneOrFetchSpan,
+	endCloneOrFetchSpanWithError,
+	endCreateWorktreeSpan,
+	endCreateWorktreeSpanWithError,
+	endResolveCommitishSpan,
+	endResolveCommitishSpanWithError,
+	startCloneOrFetchSpan,
+	startCreateWorktreeSpan,
+	startResolveCommitishSpan,
+} from "./tracing";
 
 /**
  * Lock map to prevent race conditions when cloning the same repo in parallel.
@@ -167,7 +179,7 @@ export async function cleanupWorktree(repo: Repo): Promise<boolean> {
  * @returns A Repo object with paths and metadata
  * @throws Error if the forge cannot be inferred or git operations fail
  */
-export async function connectRepo(repoUrl: string, options: ConnectOptions = {}): Promise<Repo> {
+export async function connectRepo(repoUrl: string, options: ConnectOptions = {}, parentSpan?: Span): Promise<Repo> {
 	const forgeName = options.forge ?? inferForge(repoUrl);
 	if (!forgeName) {
 		throw new MegasthenesError(
@@ -185,27 +197,47 @@ export async function connectRepo(repoUrl: string, options: ConnectOptions = {})
 	const cachePath = join(basePath, "repo");
 	const commitish = options.commitish ?? "HEAD";
 
-	await withCloneLock(cachePath, async () => {
-		// Check if bare repo exists (bare repos have HEAD directly in the directory)
-		const headFile = join(cachePath, "HEAD");
-		if (await exists(headFile)) {
-			// Valid bare repo exists - fetch if needed
-			const hasCommitish = await commitishExistsLocally(cachePath, commitish);
-			if (!hasCommitish) {
-				const proc = Bun.spawn(["git", "fetch", "origin", "--tags"], {
-					cwd: cachePath,
-					stdout: "inherit",
-					stderr: "inherit",
+	const cloneOrFetchSpan = parentSpan ? startCloneOrFetchSpan(parentSpan) : undefined;
+	try {
+		await withCloneLock(cachePath, async () => {
+			// Check if bare repo exists (bare repos have HEAD directly in the directory)
+			const headFile = join(cachePath, "HEAD");
+			const cacheExists = await exists(headFile);
+			if (cacheExists) {
+				// Valid bare repo exists - fetch if needed
+				const hasCommitish = await commitishExistsLocally(cachePath, commitish);
+				if (!hasCommitish) {
+					const proc = Bun.spawn(["git", "fetch", "origin", "--tags"], {
+						cwd: cachePath,
+						stdout: "inherit",
+						stderr: "inherit",
+					});
+					await proc.exited;
+					cloneOrFetchSpan?.addEvent("repo.fetch.started");
+					endCloneOrFetchSpan(cloneOrFetchSpan, {
+						"megasthenes.repo.cache_path": cachePath,
+						"megasthenes.repo.cache_exists": true,
+						"megasthenes.repo.commitish_present_locally": false,
+						"megasthenes.git.operation": "fetch",
+					});
+					return;
+				}
+				cloneOrFetchSpan?.addEvent("repo.cache.hit");
+				endCloneOrFetchSpan(cloneOrFetchSpan, {
+					"megasthenes.repo.cache_path": cachePath,
+					"megasthenes.repo.cache_exists": true,
+					"megasthenes.repo.commitish_present_locally": true,
+					"megasthenes.git.operation": "reuse_cache",
 				});
-				await proc.exited;
+				return;
 			}
-		} else {
 			// Clean up incomplete clone if directory exists but HEAD doesn't
 			if (await exists(cachePath)) {
 				await rm(cachePath, { recursive: true, force: true });
 			}
 			await mkdir(cachePath, { recursive: true });
 			const cloneUrl = forge.buildCloneUrl(repoUrl, options.token);
+			cloneOrFetchSpan?.addEvent("repo.clone.started");
 			const proc = Bun.spawn(["git", "clone", "--bare", "--filter=blob:none", cloneUrl, cachePath], {
 				stdout: "inherit",
 				stderr: "inherit",
@@ -216,46 +248,55 @@ export async function connectRepo(repoUrl: string, options: ConnectOptions = {})
 					isRetryable: true,
 				});
 			}
-		}
-	});
-
-	const revParseProc = Bun.spawn(["git", "rev-parse", commitish], {
-		cwd: cachePath,
-		stdout: "pipe",
-		stderr: "pipe",
-	});
-	const sha = (await new Response(revParseProc.stdout).text()).trim();
-	const revParseExit = await revParseProc.exited;
-	if (revParseExit !== 0) {
-		throw new MegasthenesError("invalid_commitish", `Failed to resolve commitish: ${commitish}`, {
-			isRetryable: false,
+			endCloneOrFetchSpan(cloneOrFetchSpan, {
+				"megasthenes.repo.cache_path": cachePath,
+				"megasthenes.repo.cache_exists": false,
+				"megasthenes.git.operation": "clone",
+				"megasthenes.git.clone.filter": "blob:none",
+			});
 		});
+	} catch (error) {
+		if (cloneOrFetchSpan?.isRecording()) {
+			endCloneOrFetchSpanWithError(cloneOrFetchSpan, "clone_failed", error);
+		}
+		throw error;
+	}
+
+	const resolveCommitishSpan = parentSpan ? startResolveCommitishSpan(parentSpan) : undefined;
+	let sha: string;
+	try {
+		const revParseProc = Bun.spawn(["git", "rev-parse", commitish], {
+			cwd: cachePath,
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		sha = (await new Response(revParseProc.stdout).text()).trim();
+		const revParseExit = await revParseProc.exited;
+		if (revParseExit !== 0) {
+			throw new MegasthenesError("invalid_commitish", `Failed to resolve commitish: ${commitish}`, {
+				isRetryable: false,
+			});
+		}
+		endResolveCommitishSpan(resolveCommitishSpan, {
+			"megasthenes.repo.requested_commitish": commitish,
+			"megasthenes.repo.commitish": sha,
+		});
+	} catch (error) {
+		if (resolveCommitishSpan?.isRecording()) {
+			endResolveCommitishSpanWithError(resolveCommitishSpan, "invalid_commitish", error);
+		}
+		throw error;
 	}
 
 	const shortSha = sha.slice(0, 12);
 	const worktreePath = resolve(basePath, "trees", shortSha);
-
-	if (await exists(worktreePath)) {
-		return {
-			url: repoUrl,
-			localPath: worktreePath,
-			forge,
-			commitish: sha,
-			cachePath: resolve(cachePath),
-		};
-	}
-
-	await mkdir(resolve(basePath, "trees"), { recursive: true });
-	const worktreeProc = Bun.spawn(["git", "worktree", "add", worktreePath, sha], {
-		cwd: cachePath,
-		stdout: "pipe",
-		stderr: "pipe",
-	});
-	const worktreeExit = await worktreeProc.exited;
-	if (worktreeExit !== 0) {
-		// Another concurrent call may have created the worktree between our exists()
-		// check and the worktree add. If so, just return it.
+	const createWorktreeSpan = parentSpan ? startCreateWorktreeSpan(parentSpan) : undefined;
+	try {
 		if (await exists(worktreePath)) {
+			endCreateWorktreeSpan(createWorktreeSpan, {
+				"megasthenes.repo.worktree_path": worktreePath,
+				"megasthenes.connect.worktree_reused": true,
+			});
 			return {
 				url: repoUrl,
 				localPath: worktreePath,
@@ -264,16 +305,50 @@ export async function connectRepo(repoUrl: string, options: ConnectOptions = {})
 				cachePath: resolve(cachePath),
 			};
 		}
-		throw new MegasthenesError("clone_failed", `git worktree add failed with exit code ${worktreeExit}`, {
-			isRetryable: true,
-		});
-	}
 
-	return {
-		url: repoUrl,
-		localPath: worktreePath,
-		forge,
-		commitish: sha,
-		cachePath: resolve(cachePath),
-	};
+		await mkdir(resolve(basePath, "trees"), { recursive: true });
+		const worktreeProc = Bun.spawn(["git", "worktree", "add", worktreePath, sha], {
+			cwd: cachePath,
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		const worktreeExit = await worktreeProc.exited;
+		if (worktreeExit !== 0) {
+			// Another concurrent call may have created the worktree between our exists()
+			// check and the worktree add. If so, just return it.
+			if (await exists(worktreePath)) {
+				endCreateWorktreeSpan(createWorktreeSpan, {
+					"megasthenes.repo.worktree_path": worktreePath,
+					"megasthenes.connect.worktree_reused": true,
+				});
+				return {
+					url: repoUrl,
+					localPath: worktreePath,
+					forge,
+					commitish: sha,
+					cachePath: resolve(cachePath),
+				};
+			}
+			throw new MegasthenesError("clone_failed", `git worktree add failed with exit code ${worktreeExit}`, {
+				isRetryable: true,
+			});
+		}
+		endCreateWorktreeSpan(createWorktreeSpan, {
+			"megasthenes.repo.worktree_path": worktreePath,
+			"megasthenes.connect.worktree_reused": false,
+		});
+
+		return {
+			url: repoUrl,
+			localPath: worktreePath,
+			forge,
+			commitish: sha,
+			cachePath: resolve(cachePath),
+		};
+	} catch (error) {
+		if (createWorktreeSpan?.isRecording()) {
+			endCreateWorktreeSpanWithError(createWorktreeSpan, "clone_failed", error);
+		}
+		throw error;
+	}
 }

--- a/src/forge.ts
+++ b/src/forge.ts
@@ -3,17 +3,7 @@ import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 import type { Span } from "@opentelemetry/api";
 import { MegasthenesError } from "./errors";
-import {
-	endCloneOrFetchSpan,
-	endCloneOrFetchSpanWithError,
-	endCreateWorktreeSpan,
-	endCreateWorktreeSpanWithError,
-	endResolveCommitishSpan,
-	endResolveCommitishSpanWithError,
-	startCloneOrFetchSpan,
-	startCreateWorktreeSpan,
-	startResolveCommitishSpan,
-} from "./tracing";
+import { endChildSpan, withChildSpan } from "./tracing";
 
 /**
  * Lock map to prevent race conditions when cloning the same repo in parallel.
@@ -197,8 +187,7 @@ export async function connectRepo(repoUrl: string, options: ConnectOptions = {},
 	const cachePath = join(basePath, "repo");
 	const commitish = options.commitish ?? "HEAD";
 
-	const cloneOrFetchSpan = parentSpan ? startCloneOrFetchSpan(parentSpan) : undefined;
-	try {
+	await withChildSpan(parentSpan, "repo.clone_or_fetch", "clone_failed", async (span) => {
 		await withCloneLock(cachePath, async () => {
 			// Check if bare repo exists (bare repos have HEAD directly in the directory)
 			const headFile = join(cachePath, "HEAD");
@@ -213,8 +202,8 @@ export async function connectRepo(repoUrl: string, options: ConnectOptions = {},
 						stderr: "inherit",
 					});
 					await proc.exited;
-					cloneOrFetchSpan?.addEvent("repo.fetch.started");
-					endCloneOrFetchSpan(cloneOrFetchSpan, {
+					span?.addEvent("repo.fetch.started");
+					endChildSpan(span, {
 						"megasthenes.repo.cache_path": cachePath,
 						"megasthenes.repo.cache_exists": true,
 						"megasthenes.repo.commitish_present_locally": false,
@@ -222,8 +211,8 @@ export async function connectRepo(repoUrl: string, options: ConnectOptions = {},
 					});
 					return;
 				}
-				cloneOrFetchSpan?.addEvent("repo.cache.hit");
-				endCloneOrFetchSpan(cloneOrFetchSpan, {
+				span?.addEvent("repo.cache.hit");
+				endChildSpan(span, {
 					"megasthenes.repo.cache_path": cachePath,
 					"megasthenes.repo.cache_exists": true,
 					"megasthenes.repo.commitish_present_locally": true,
@@ -237,7 +226,7 @@ export async function connectRepo(repoUrl: string, options: ConnectOptions = {},
 			}
 			await mkdir(cachePath, { recursive: true });
 			const cloneUrl = forge.buildCloneUrl(repoUrl, options.token);
-			cloneOrFetchSpan?.addEvent("repo.clone.started");
+			span?.addEvent("repo.clone.started");
 			const proc = Bun.spawn(["git", "clone", "--bare", "--filter=blob:none", cloneUrl, cachePath], {
 				stdout: "inherit",
 				stderr: "inherit",
@@ -248,54 +237,42 @@ export async function connectRepo(repoUrl: string, options: ConnectOptions = {},
 					isRetryable: true,
 				});
 			}
-			endCloneOrFetchSpan(cloneOrFetchSpan, {
+			endChildSpan(span, {
 				"megasthenes.repo.cache_path": cachePath,
 				"megasthenes.repo.cache_exists": false,
 				"megasthenes.git.operation": "clone",
 				"megasthenes.git.clone.filter": "blob:none",
 			});
 		});
-	} catch (error) {
-		if (cloneOrFetchSpan?.isRecording()) {
-			endCloneOrFetchSpanWithError(cloneOrFetchSpan, "clone_failed", error);
-		}
-		throw error;
-	}
+	});
 
-	const resolveCommitishSpan = parentSpan ? startResolveCommitishSpan(parentSpan) : undefined;
-	let sha: string;
-	try {
+	const sha = await withChildSpan(parentSpan, "repo.resolve_commitish", "invalid_commitish", async (span) => {
 		const revParseProc = Bun.spawn(["git", "rev-parse", commitish], {
 			cwd: cachePath,
 			stdout: "pipe",
 			stderr: "pipe",
 		});
-		sha = (await new Response(revParseProc.stdout).text()).trim();
+		const resolved = (await new Response(revParseProc.stdout).text()).trim();
 		const revParseExit = await revParseProc.exited;
 		if (revParseExit !== 0) {
 			throw new MegasthenesError("invalid_commitish", `Failed to resolve commitish: ${commitish}`, {
 				isRetryable: false,
 			});
 		}
-		endResolveCommitishSpan(resolveCommitishSpan, {
+		endChildSpan(span, {
 			"megasthenes.repo.requested_commitish": commitish,
-			"megasthenes.repo.commitish": sha,
+			"megasthenes.repo.commitish": resolved,
 		});
-	} catch (error) {
-		if (resolveCommitishSpan?.isRecording()) {
-			endResolveCommitishSpanWithError(resolveCommitishSpan, "invalid_commitish", error);
-		}
-		throw error;
-	}
+		return resolved;
+	});
 
 	const shortSha = sha.slice(0, 12);
 	const worktreePath = resolve(basePath, "trees", shortSha);
-	const createWorktreeSpan = parentSpan ? startCreateWorktreeSpan(parentSpan) : undefined;
-	try {
-		if (await exists(worktreePath)) {
-			endCreateWorktreeSpan(createWorktreeSpan, {
+	return withChildSpan(parentSpan, "repo.create_worktree", "clone_failed", async (span) => {
+		const makeRepo = (reused: boolean): Repo => {
+			endChildSpan(span, {
 				"megasthenes.repo.worktree_path": worktreePath,
-				"megasthenes.connect.worktree_reused": true,
+				"megasthenes.connect.worktree_reused": reused,
 			});
 			return {
 				url: repoUrl,
@@ -304,6 +281,10 @@ export async function connectRepo(repoUrl: string, options: ConnectOptions = {},
 				commitish: sha,
 				cachePath: resolve(cachePath),
 			};
+		};
+
+		if (await exists(worktreePath)) {
+			return makeRepo(true);
 		}
 
 		await mkdir(resolve(basePath, "trees"), { recursive: true });
@@ -317,38 +298,12 @@ export async function connectRepo(repoUrl: string, options: ConnectOptions = {},
 			// Another concurrent call may have created the worktree between our exists()
 			// check and the worktree add. If so, just return it.
 			if (await exists(worktreePath)) {
-				endCreateWorktreeSpan(createWorktreeSpan, {
-					"megasthenes.repo.worktree_path": worktreePath,
-					"megasthenes.connect.worktree_reused": true,
-				});
-				return {
-					url: repoUrl,
-					localPath: worktreePath,
-					forge,
-					commitish: sha,
-					cachePath: resolve(cachePath),
-				};
+				return makeRepo(true);
 			}
 			throw new MegasthenesError("clone_failed", `git worktree add failed with exit code ${worktreeExit}`, {
 				isRetryable: true,
 			});
 		}
-		endCreateWorktreeSpan(createWorktreeSpan, {
-			"megasthenes.repo.worktree_path": worktreePath,
-			"megasthenes.connect.worktree_reused": false,
-		});
-
-		return {
-			url: repoUrl,
-			localPath: worktreePath,
-			forge,
-			commitish: sha,
-			cachePath: resolve(cachePath),
-		};
-	} catch (error) {
-		if (createWorktreeSpan?.isRecording()) {
-			endCreateWorktreeSpanWithError(createWorktreeSpan, "clone_failed", error);
-		}
-		throw error;
-	}
+		return makeRepo(false);
+	});
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,7 +110,16 @@ export interface SessionConfig {
  *   model: { provider: "anthropic", id: "claude-sonnet-4-6" },
  *   maxIterations: 20,
  * });
+ * try {
+ *   for await (const ev of session.ask("...")) { ... }
+ * } finally {
+ *   await session.close();
+ * }
  * ```
+ *
+ * **Always close the returned session.** `connect()` starts a root OTel span
+ * that only ends in `Session.close()`; skipping close causes the entire trace
+ * tree for that session to be dropped. See `Session.close()` for details.
  */
 function classifyConnectError(error: unknown): ErrorType {
 	if (error instanceof MegasthenesError) {
@@ -134,6 +143,11 @@ export class Client {
 
 	/**
 	 * Connect to a repository and create a session.
+	 *
+	 * Starts a root OTel "ask" span that lives until `Session.close()` is called.
+	 * The caller MUST invoke `session.close()` (typically in a `finally` block)
+	 * or the root span never ends and the OTel SDK drops the whole trace on
+	 * shutdown. See `Session.close()` for details.
 	 *
 	 * @param config - Session configuration (repo, model, iterations, etc.)
 	 * @param onProgress - Optional callback for clone progress messages

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { consoleLogger, type Logger, nullLogger } from "./logger";
 import { buildDefaultSystemPrompt } from "./prompt";
 import { SandboxClient, type SandboxClientConfig } from "./sandbox/client";
 import { type PublicSessionConfig, Session } from "./session";
+import { executeTool, tools } from "./tools";
 import {
 	annotateRootAskSpan,
 	endConnectSpan,
@@ -15,7 +16,6 @@ import {
 	startConnectSpan,
 	startRootAskSpan,
 } from "./tracing";
-import { executeTool, tools } from "./tools";
 import type {
 	AskOptions,
 	AskStream,

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,10 +10,10 @@ import { type PublicSessionConfig, Session } from "./session";
 import { executeTool, tools } from "./tools";
 import {
 	annotateRootAskSpan,
-	endConnectSpan,
-	endConnectSpanWithError,
+	endChildSpan,
+	endChildSpanWithError,
 	endRootAskSpanWithError,
-	startConnectSpan,
+	startChildSpan,
 	startRootAskSpan,
 } from "./tracing";
 import type {
@@ -148,10 +148,10 @@ export class Client {
 			requestedCommitish,
 			mode: connectMode,
 		});
-		const connectSpan = startConnectSpan(traceRoot, {
-			repoUrl: repoConfig.url,
-			requestedCommitish,
-			mode: connectMode,
+		const connectSpan = startChildSpan(traceRoot, "connect", {
+			"megasthenes.repo.url": repoConfig.url,
+			"megasthenes.repo.requested_commitish": requestedCommitish,
+			"megasthenes.connect.mode": connectMode,
 		});
 
 		try {
@@ -206,7 +206,7 @@ export class Client {
 					commitish: repo.commitish,
 					localPath: repo.localPath,
 				});
-				endConnectSpan(connectSpan);
+				endChildSpan(connectSpan);
 				return session;
 			}
 
@@ -241,11 +241,11 @@ export class Client {
 				commitish: repo.commitish,
 				localPath: repo.localPath,
 			});
-			endConnectSpan(connectSpan);
+			endChildSpan(connectSpan);
 			return session;
 		} catch (error) {
 			const errorType = classifyConnectError(error);
-			endConnectSpanWithError(connectSpan, errorType, error);
+			endChildSpanWithError(connectSpan, errorType, error);
 			endRootAskSpanWithError(traceRoot.rootSpan, errorType, error);
 			throw error;
 		}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,20 @@
 import { getModel, type KnownProvider, type Message, stream, streamSimple } from "@mariozechner/pi-ai";
 import type { CompactionSettings, ThinkingConfig } from "./config";
+import { classifyThrownError } from "./error-classification";
 import { MegasthenesError } from "./errors";
 import { type ConnectOptions, connectRepo, type Forge, type ForgeName, type Repo } from "./forge";
 import { consoleLogger, type Logger, nullLogger } from "./logger";
 import { buildDefaultSystemPrompt } from "./prompt";
 import { SandboxClient, type SandboxClientConfig } from "./sandbox/client";
 import { type PublicSessionConfig, Session } from "./session";
+import {
+	annotateRootAskSpan,
+	endConnectSpan,
+	endConnectSpanWithError,
+	endRootAskSpanWithError,
+	startConnectSpan,
+	startRootAskSpan,
+} from "./tracing";
 import { executeTool, tools } from "./tools";
 import type {
 	AskOptions,
@@ -103,6 +112,14 @@ export interface SessionConfig {
  * });
  * ```
  */
+function classifyConnectError(error: unknown): ErrorType {
+	if (error instanceof MegasthenesError) {
+		return error.errorType;
+	}
+	const classified = classifyThrownError(error);
+	return classified.errorType === "network_error" ? "network_error" : "internal_error";
+}
+
 export class Client {
 	readonly #logger: Logger;
 	readonly #sandboxClient?: SandboxClient;
@@ -124,70 +141,114 @@ export class Client {
 	 */
 	async connect(config: SessionConfig, onProgress?: (message: string) => void): Promise<Session> {
 		const { repo: repoConfig, model: modelConfig } = config;
-
-		// getModel has strict generics tying provider to model IDs - cast for flexibility
-		const model = (getModel as (p: string, m: string) => ReturnType<typeof getModel>)(
-			modelConfig.provider,
-			modelConfig.id,
-		);
-
-		if (this.#sandboxClient) {
-			const cloneResult = await this.#sandboxClient.clone(repoConfig.url, repoConfig.commitish, onProgress);
-
-			const repo: Repo = {
-				url: repoConfig.url,
-				localPath: cloneResult.worktree,
-				forge: { name: "github", buildCloneUrl: (url) => url },
-				commitish: cloneResult.sha,
-				cachePath: "",
-			};
-
-			const sandboxClient = this.#sandboxClient;
-			const sandboxExecuteTool = async (name: string, args: Record<string, unknown>, _cwd: string) => {
-				return sandboxClient.executeTool(cloneResult.slug, cloneResult.sha, name, args);
-			};
-
-			const systemPrompt = config.systemPrompt ?? buildDefaultSystemPrompt(repoConfig.url, repo.commitish);
-
-			return new Session(repo, {
-				model,
-				systemPrompt,
-				tools,
-				maxIterations: config.maxIterations,
-				executeTool: sandboxExecuteTool,
-				logger: this.#logger,
-				stream,
-				streamSimple,
-				compaction: config.compaction,
-				thinking: config.thinking,
-				initialTurns: config.initialTurns,
-				lastCompactionSummary: config.lastCompactionSummary,
-			});
-		}
-
-		// Local mode
-		const connectOptions: ConnectOptions = {
-			token: repoConfig.token,
-			commitish: repoConfig.commitish,
-			forge: repoConfig.forge,
-		};
-		const repo = await connectRepo(repoConfig.url, connectOptions);
-		const systemPrompt = config.systemPrompt ?? buildDefaultSystemPrompt(repoConfig.url, repo.commitish);
-
-		return new Session(repo, {
-			model,
-			systemPrompt,
-			tools,
-			maxIterations: config.maxIterations,
-			executeTool,
-			logger: this.#logger,
-			stream,
-			streamSimple,
-			compaction: config.compaction,
-			thinking: config.thinking,
-			initialTurns: config.initialTurns,
-			lastCompactionSummary: config.lastCompactionSummary,
+		const requestedCommitish = repoConfig.commitish ?? "HEAD";
+		const connectMode = this.#sandboxClient ? "sandbox" : "local";
+		const traceRoot = startRootAskSpan({
+			repoUrl: repoConfig.url,
+			requestedCommitish,
+			mode: connectMode,
 		});
+		const connectSpan = startConnectSpan(traceRoot, {
+			repoUrl: repoConfig.url,
+			requestedCommitish,
+			mode: connectMode,
+		});
+
+		try {
+			// getModel has strict generics tying provider to model IDs - cast for flexibility
+			const model = (getModel as (p: string, m: string) => ReturnType<typeof getModel>)(
+				modelConfig.provider,
+				modelConfig.id,
+			);
+
+			if (this.#sandboxClient) {
+				const cloneResult = await this.#sandboxClient.clone(
+					repoConfig.url,
+					repoConfig.commitish,
+					onProgress,
+					connectSpan,
+				);
+
+				const repo: Repo = {
+					url: repoConfig.url,
+					localPath: cloneResult.worktree,
+					forge: { name: "github", buildCloneUrl: (url) => url },
+					commitish: cloneResult.sha,
+					cachePath: "",
+				};
+
+				const sandboxClient = this.#sandboxClient;
+				const sandboxExecuteTool = async (name: string, args: Record<string, unknown>, _cwd: string) => {
+					return sandboxClient.executeTool(cloneResult.slug, cloneResult.sha, name, args);
+				};
+
+				const systemPrompt = config.systemPrompt ?? buildDefaultSystemPrompt(repoConfig.url, repo.commitish);
+				const session = new Session(
+					repo,
+					{
+						model,
+						systemPrompt,
+						tools,
+						maxIterations: config.maxIterations,
+						executeTool: sandboxExecuteTool,
+						logger: this.#logger,
+						stream,
+						streamSimple,
+						compaction: config.compaction,
+						thinking: config.thinking,
+						initialTurns: config.initialTurns,
+						lastCompactionSummary: config.lastCompactionSummary,
+					},
+					traceRoot,
+				);
+				annotateRootAskSpan(traceRoot.rootSpan, {
+					sessionId: session.id,
+					commitish: repo.commitish,
+					localPath: repo.localPath,
+				});
+				endConnectSpan(connectSpan);
+				return session;
+			}
+
+			// Local mode
+			const connectOptions: ConnectOptions = {
+				token: repoConfig.token,
+				commitish: repoConfig.commitish,
+				forge: repoConfig.forge,
+			};
+			const repo = await connectRepo(repoConfig.url, connectOptions, connectSpan);
+			const systemPrompt = config.systemPrompt ?? buildDefaultSystemPrompt(repoConfig.url, repo.commitish);
+			const session = new Session(
+				repo,
+				{
+					model,
+					systemPrompt,
+					tools,
+					maxIterations: config.maxIterations,
+					executeTool,
+					logger: this.#logger,
+					stream,
+					streamSimple,
+					compaction: config.compaction,
+					thinking: config.thinking,
+					initialTurns: config.initialTurns,
+					lastCompactionSummary: config.lastCompactionSummary,
+				},
+				traceRoot,
+			);
+			annotateRootAskSpan(traceRoot.rootSpan, {
+				sessionId: session.id,
+				commitish: repo.commitish,
+				localPath: repo.localPath,
+			});
+			endConnectSpan(connectSpan);
+			return session;
+		} catch (error) {
+			const errorType = classifyConnectError(error);
+			endConnectSpanWithError(connectSpan, errorType, error);
+			endRootAskSpanWithError(traceRoot.rootSpan, errorType, error);
+			throw error;
+		}
 	}
 
 	/**

--- a/src/sandbox/client.ts
+++ b/src/sandbox/client.ts
@@ -33,6 +33,23 @@ const CLONE_POLL_INITIAL_INTERVAL_MS = 1_000;
 /** Maximum interval between clone status polls. */
 const CLONE_POLL_MAX_INTERVAL_MS = 5_000;
 
+function completeClone(
+	cloneSpan: Span | undefined,
+	onProgress: ((message: string) => void) | undefined,
+	body: { slug?: string; sha: string; worktree: string },
+	slugFallback?: string,
+): CloneResult {
+	const slug = body.slug ?? slugFallback;
+	if (!slug) throw new Error("Sandbox clone: ready response missing slug");
+	onProgress?.("Repository ready");
+	endChildSpan(cloneSpan, {
+		"megasthenes.sandbox.slug": slug,
+		"megasthenes.repo.commitish": body.sha,
+		"megasthenes.repo.local_path": body.worktree,
+	});
+	return { slug, sha: body.sha, worktree: body.worktree };
+}
+
 export class SandboxClient {
 	private config: SandboxClientConfig;
 	private logger: Logger;
@@ -130,13 +147,11 @@ export class SandboxClient {
 					`POST /clone → ready (cached) (${duration}ms) slug=${startBody.slug} sha=${startBody.sha.slice(0, 12)}`,
 				);
 				cloneSpan?.addEvent("sandbox.clone.cached_ready", { elapsed_ms: duration });
-				onProgress?.("Repository ready");
-				endChildSpan(cloneSpan, {
-					"megasthenes.sandbox.slug": startBody.slug,
-					"megasthenes.repo.commitish": startBody.sha,
-					"megasthenes.repo.local_path": startBody.worktree,
+				return completeClone(cloneSpan, onProgress, {
+					slug: startBody.slug,
+					sha: startBody.sha,
+					worktree: startBody.worktree,
 				});
-				return { slug: startBody.slug, sha: startBody.sha, worktree: startBody.worktree };
 			}
 
 			const slug = startBody.slug;
@@ -199,13 +214,11 @@ export class SandboxClient {
 							`clone ready on retry (${duration}ms) slug=${retryBody.slug} sha=${retryBody.sha.slice(0, 12)}`,
 						);
 						cloneSpan?.addEvent("sandbox.clone.ready", { elapsed_ms: duration, slug: retryBody.slug });
-						onProgress?.("Repository ready");
-						endChildSpan(cloneSpan, {
-							"megasthenes.sandbox.slug": retryBody.slug,
-							"megasthenes.repo.commitish": retryBody.sha,
-							"megasthenes.repo.local_path": retryBody.worktree,
+						return completeClone(cloneSpan, onProgress, {
+							slug: retryBody.slug,
+							sha: retryBody.sha,
+							worktree: retryBody.worktree,
 						});
-						return { slug: retryBody.slug, sha: retryBody.sha, worktree: retryBody.worktree };
 					}
 
 					// Otherwise continue polling for the re-triggered job
@@ -229,13 +242,12 @@ export class SandboxClient {
 						`clone ready (${duration}ms) slug=${slug} sha=${statusBody.sha.slice(0, 12)}`,
 					);
 					cloneSpan?.addEvent("sandbox.clone.ready", { elapsed_ms: duration, slug });
-					onProgress?.("Repository ready");
-					endChildSpan(cloneSpan, {
-						"megasthenes.sandbox.slug": statusBody.slug ?? slug,
-						"megasthenes.repo.commitish": statusBody.sha,
-						"megasthenes.repo.local_path": statusBody.worktree,
-					});
-					return { slug: statusBody.slug ?? slug, sha: statusBody.sha, worktree: statusBody.worktree };
+					return completeClone(
+						cloneSpan,
+						onProgress,
+						{ slug: statusBody.slug, sha: statusBody.sha, worktree: statusBody.worktree },
+						slug,
+					);
 				}
 
 				if (statusBody.status === "failed") {

--- a/src/sandbox/client.ts
+++ b/src/sandbox/client.ts
@@ -5,7 +5,10 @@
  * to the isolated container. Communicates over HTTP on the compose internal network.
  */
 
+import type { Span } from "@opentelemetry/api";
+import { classifyThrownError } from "../error-classification";
 import { type Logger, nullLogger } from "../logger";
+import { endSandboxCloneSpan, endSandboxCloneSpanWithError, startSandboxCloneSpan } from "../tracing";
 
 /** Configuration for connecting to a sandbox worker. */
 export interface SandboxClientConfig {
@@ -83,140 +86,180 @@ export class SandboxClient {
 	 * Kicks off an async clone and polls until ready (up to 20 minutes).
 	 * @param onProgress - Optional callback invoked with status messages during polling
 	 */
-	async clone(url: string, commitish?: string, onProgress?: (message: string) => void): Promise<CloneResult> {
+	async clone(
+		url: string,
+		commitish?: string,
+		onProgress?: (message: string) => void,
+		parentSpan?: Span,
+	): Promise<CloneResult> {
 		const commit = commitish ?? "HEAD";
 		this.logger.debug("sandbox:client", `POST /clone url=${url} commitish=${commit}`);
 		const t0 = Date.now();
+		const cloneSpan = parentSpan ? startSandboxCloneSpan(parentSpan) : undefined;
 
-		// Step 1: Kick off clone
-		const startRes = await fetch(`${this.config.baseUrl}/clone`, {
-			method: "POST",
-			headers: { "Content-Type": "application/json", ...this.authHeaders() },
-			body: JSON.stringify({ url, commitish }),
-			signal: AbortSignal.timeout(30_000), // Starting a clone should be fast
-		});
+		try {
+			cloneSpan?.addEvent("sandbox.clone.started", { url, commitish: commit });
 
-		const startBody = (await startRes.json()) as {
-			ok: boolean;
-			status?: string;
-			slug?: string;
-			sha?: string;
-			worktree?: string;
-			error?: string;
-		};
+			// Step 1: Kick off clone
+			const startRes = await fetch(`${this.config.baseUrl}/clone`, {
+				method: "POST",
+				headers: { "Content-Type": "application/json", ...this.authHeaders() },
+				body: JSON.stringify({ url, commitish }),
+				signal: AbortSignal.timeout(30_000), // Starting a clone should be fast
+			});
 
-		if (!startBody.ok) {
-			this.logger.error("sandbox:client", new Error(`POST /clone → ${startRes.status}: ${startBody.error}`));
-			throw new Error(`Sandbox clone failed: ${startBody.error}`);
-		}
-
-		// Already ready (cached)
-		if (startBody.status === "ready" && startBody.slug && startBody.sha && startBody.worktree) {
-			const duration = Date.now() - t0;
-			this.logger.debug(
-				"sandbox:client",
-				`POST /clone → ready (cached) (${duration}ms) slug=${startBody.slug} sha=${startBody.sha.slice(0, 12)}`,
-			);
-			onProgress?.("Repository ready");
-			return { slug: startBody.slug, sha: startBody.sha, worktree: startBody.worktree };
-		}
-
-		const slug = startBody.slug;
-		if (!slug) {
-			throw new Error("Sandbox clone failed: no slug returned");
-		}
-
-		// Step 2: Poll until ready or failed
-		this.logger.debug("sandbox:client", `clone started for ${url}, polling status...`);
-		onProgress?.("Cloning repository…");
-
-		const deadline = Date.now() + CLONE_POLL_TIMEOUT_MS;
-		let pollInterval = CLONE_POLL_INITIAL_INTERVAL_MS;
-		while (Date.now() < deadline) {
-			await Bun.sleep(pollInterval);
-			pollInterval = Math.min(pollInterval * 1.5, CLONE_POLL_MAX_INTERVAL_MS);
-
-			const statusRes = await fetch(
-				`${this.config.baseUrl}/clone/status/${slug}?commitish=${encodeURIComponent(commit)}`,
-				{
-					headers: { ...this.authHeaders() },
-					signal: AbortSignal.timeout(10_000),
-				},
-			);
-
-			if (statusRes.status === 404) {
-				this.logger.warn("sandbox:client", `clone job not found for ${slug}, re-triggering clone for ${url}`);
-				onProgress?.("Re-cloning repository…");
-
-				const retryRes = await fetch(`${this.config.baseUrl}/clone`, {
-					method: "POST",
-					headers: { "Content-Type": "application/json", ...this.authHeaders() },
-					body: JSON.stringify({ url, commitish }),
-					signal: AbortSignal.timeout(30_000),
-				});
-
-				const retryBody = (await retryRes.json()) as {
-					ok: boolean;
-					status?: string;
-					slug?: string;
-					sha?: string;
-					worktree?: string;
-					error?: string;
-				};
-
-				if (!retryBody.ok) {
-					throw new Error(`Sandbox clone failed on retry: ${retryBody.error}`);
-				}
-
-				// If the re-triggered clone is already cached/ready, return immediately
-				if (retryBody.status === "ready" && retryBody.slug && retryBody.sha && retryBody.worktree) {
-					const duration = Date.now() - t0;
-					this.logger.debug(
-						"sandbox:client",
-						`clone ready on retry (${duration}ms) slug=${retryBody.slug} sha=${retryBody.sha.slice(0, 12)}`,
-					);
-					onProgress?.("Repository ready");
-					return { slug: retryBody.slug, sha: retryBody.sha, worktree: retryBody.worktree };
-				}
-
-				// Otherwise continue polling for the re-triggered job
-				continue;
-			}
-
-			const statusBody = (await statusRes.json()) as {
+			const startBody = (await startRes.json()) as {
 				ok: boolean;
 				status?: string;
 				slug?: string;
 				sha?: string;
 				worktree?: string;
 				error?: string;
-				elapsedMs?: number;
 			};
 
-			if (statusBody.status === "ready" && statusBody.sha && statusBody.worktree) {
+			if (!startBody.ok) {
+				this.logger.error("sandbox:client", new Error(`POST /clone → ${startRes.status}: ${startBody.error}`));
+				throw new Error(`Sandbox clone failed: ${startBody.error}`);
+			}
+
+			// Already ready (cached)
+			if (startBody.status === "ready" && startBody.slug && startBody.sha && startBody.worktree) {
 				const duration = Date.now() - t0;
 				this.logger.debug(
 					"sandbox:client",
-					`clone ready (${duration}ms) slug=${slug} sha=${statusBody.sha.slice(0, 12)}`,
+					`POST /clone → ready (cached) (${duration}ms) slug=${startBody.slug} sha=${startBody.sha.slice(0, 12)}`,
 				);
+				cloneSpan?.addEvent("sandbox.clone.cached_ready", { elapsed_ms: duration });
 				onProgress?.("Repository ready");
-				return { slug: statusBody.slug ?? slug, sha: statusBody.sha, worktree: statusBody.worktree };
+				endSandboxCloneSpan(cloneSpan, {
+					"megasthenes.sandbox.slug": startBody.slug,
+					"megasthenes.repo.commitish": startBody.sha,
+					"megasthenes.repo.local_path": startBody.worktree,
+				});
+				return { slug: startBody.slug, sha: startBody.sha, worktree: startBody.worktree };
 			}
 
-			if (statusBody.status === "failed") {
-				const duration = Date.now() - t0;
-				this.logger.error("sandbox:client", new Error(`clone failed after ${duration}ms: ${statusBody.error}`));
-				throw new Error(`Sandbox clone failed: ${statusBody.error}`);
+			const slug = startBody.slug;
+			if (!slug) {
+				throw new Error("Sandbox clone failed: no slug returned");
 			}
 
-			// Still cloning — log progress
-			const elapsed = statusBody.elapsedMs ?? Date.now() - t0;
-			const elapsedSec = Math.round(elapsed / 1000);
-			this.logger.debug("sandbox:client", `clone in progress for ${url} (${elapsedSec}s elapsed)`);
-			onProgress?.(`Cloning repository… ${elapsedSec}s`);
+			// Step 2: Poll until ready or failed
+			this.logger.debug("sandbox:client", `clone started for ${url}, polling status...`);
+			onProgress?.("Cloning repository…");
+
+			const deadline = Date.now() + CLONE_POLL_TIMEOUT_MS;
+			let pollInterval = CLONE_POLL_INITIAL_INTERVAL_MS;
+			while (Date.now() < deadline) {
+				await Bun.sleep(pollInterval);
+				pollInterval = Math.min(pollInterval * 1.5, CLONE_POLL_MAX_INTERVAL_MS);
+				cloneSpan?.addEvent("sandbox.clone.poll", {
+					elapsed_ms: Date.now() - t0,
+					poll_interval_ms: pollInterval,
+				});
+
+				const statusRes = await fetch(
+					`${this.config.baseUrl}/clone/status/${slug}?commitish=${encodeURIComponent(commit)}`,
+					{
+						headers: { ...this.authHeaders() },
+						signal: AbortSignal.timeout(10_000),
+					},
+				);
+
+				if (statusRes.status === 404) {
+					this.logger.warn("sandbox:client", `clone job not found for ${slug}, re-triggering clone for ${url}`);
+					cloneSpan?.addEvent("sandbox.clone.retry_after_404", { slug });
+					onProgress?.("Re-cloning repository…");
+
+					const retryRes = await fetch(`${this.config.baseUrl}/clone`, {
+						method: "POST",
+						headers: { "Content-Type": "application/json", ...this.authHeaders() },
+						body: JSON.stringify({ url, commitish }),
+						signal: AbortSignal.timeout(30_000),
+					});
+
+					const retryBody = (await retryRes.json()) as {
+						ok: boolean;
+						status?: string;
+						slug?: string;
+						sha?: string;
+						worktree?: string;
+						error?: string;
+					};
+
+					if (!retryBody.ok) {
+						throw new Error(`Sandbox clone failed on retry: ${retryBody.error}`);
+					}
+
+					// If the re-triggered clone is already cached/ready, return immediately
+					if (retryBody.status === "ready" && retryBody.slug && retryBody.sha && retryBody.worktree) {
+						const duration = Date.now() - t0;
+						this.logger.debug(
+							"sandbox:client",
+							`clone ready on retry (${duration}ms) slug=${retryBody.slug} sha=${retryBody.sha.slice(0, 12)}`,
+						);
+						cloneSpan?.addEvent("sandbox.clone.ready", { elapsed_ms: duration, slug: retryBody.slug });
+						onProgress?.("Repository ready");
+						endSandboxCloneSpan(cloneSpan, {
+							"megasthenes.sandbox.slug": retryBody.slug,
+							"megasthenes.repo.commitish": retryBody.sha,
+							"megasthenes.repo.local_path": retryBody.worktree,
+						});
+						return { slug: retryBody.slug, sha: retryBody.sha, worktree: retryBody.worktree };
+					}
+
+					// Otherwise continue polling for the re-triggered job
+					continue;
+				}
+
+				const statusBody = (await statusRes.json()) as {
+					ok: boolean;
+					status?: string;
+					slug?: string;
+					sha?: string;
+					worktree?: string;
+					error?: string;
+					elapsedMs?: number;
+				};
+
+				if (statusBody.status === "ready" && statusBody.sha && statusBody.worktree) {
+					const duration = Date.now() - t0;
+					this.logger.debug(
+						"sandbox:client",
+						`clone ready (${duration}ms) slug=${slug} sha=${statusBody.sha.slice(0, 12)}`,
+					);
+					cloneSpan?.addEvent("sandbox.clone.ready", { elapsed_ms: duration, slug });
+					onProgress?.("Repository ready");
+					endSandboxCloneSpan(cloneSpan, {
+						"megasthenes.sandbox.slug": statusBody.slug ?? slug,
+						"megasthenes.repo.commitish": statusBody.sha,
+						"megasthenes.repo.local_path": statusBody.worktree,
+					});
+					return { slug: statusBody.slug ?? slug, sha: statusBody.sha, worktree: statusBody.worktree };
+				}
+
+				if (statusBody.status === "failed") {
+					const duration = Date.now() - t0;
+					cloneSpan?.addEvent("sandbox.clone.failed", { elapsed_ms: duration, slug });
+					this.logger.error("sandbox:client", new Error(`clone failed after ${duration}ms: ${statusBody.error}`));
+					throw new Error(`Sandbox clone failed: ${statusBody.error}`);
+				}
+
+				// Still cloning — log progress
+				const elapsed = statusBody.elapsedMs ?? Date.now() - t0;
+				const elapsedSec = Math.round(elapsed / 1000);
+				this.logger.debug("sandbox:client", `clone in progress for ${url} (${elapsedSec}s elapsed)`);
+				onProgress?.(`Cloning repository… ${elapsedSec}s`);
+			}
+
+			cloneSpan?.addEvent("sandbox.clone.timed_out", { timeout_ms: CLONE_POLL_TIMEOUT_MS, slug });
+			throw new Error(`Sandbox clone timed out after ${CLONE_POLL_TIMEOUT_MS / 1000}s for ${url}`);
+		} catch (error) {
+			const classified = classifyThrownError(error);
+			const errorType = classified.errorType === "network_error" ? "network_error" : "clone_failed";
+			endSandboxCloneSpanWithError(cloneSpan, errorType, error);
+			throw error;
 		}
-
-		throw new Error(`Sandbox clone timed out after ${CLONE_POLL_TIMEOUT_MS / 1000}s for ${url}`);
 	}
 
 	/** Execute a tool inside the sandbox against a previously-cloned repo. */

--- a/src/sandbox/client.ts
+++ b/src/sandbox/client.ts
@@ -165,13 +165,10 @@ export class SandboxClient {
 
 			const deadline = Date.now() + CLONE_POLL_TIMEOUT_MS;
 			let pollInterval = CLONE_POLL_INITIAL_INTERVAL_MS;
+			let lastStatus: string | undefined;
 			while (Date.now() < deadline) {
 				await Bun.sleep(pollInterval);
 				pollInterval = Math.min(pollInterval * 1.5, CLONE_POLL_MAX_INTERVAL_MS);
-				cloneSpan?.addEvent("sandbox.clone.poll", {
-					elapsed_ms: Date.now() - t0,
-					poll_interval_ms: pollInterval,
-				});
 
 				const statusRes = await fetch(
 					`${this.config.baseUrl}/clone/status/${slug}?commitish=${encodeURIComponent(commit)}`,
@@ -234,6 +231,15 @@ export class SandboxClient {
 					error?: string;
 					elapsedMs?: number;
 				};
+
+				if (statusBody.status !== lastStatus) {
+					cloneSpan?.addEvent("sandbox.clone.poll", {
+						elapsed_ms: Date.now() - t0,
+						status: statusBody.status ?? "unknown",
+						previous_status: lastStatus ?? "none",
+					});
+					lastStatus = statusBody.status;
+				}
 
 				if (statusBody.status === "ready" && statusBody.sha && statusBody.worktree) {
 					const duration = Date.now() - t0;

--- a/src/sandbox/client.ts
+++ b/src/sandbox/client.ts
@@ -7,8 +7,10 @@
 
 import type { Span } from "@opentelemetry/api";
 import { classifyThrownError } from "../error-classification";
+import { MegasthenesError } from "../errors";
 import { type Logger, nullLogger } from "../logger";
 import { endChildSpan, endChildSpanWithError, startChildSpan } from "../tracing";
+import type { ErrorType } from "../types";
 
 /** Configuration for connecting to a sandbox worker. */
 export interface SandboxClientConfig {
@@ -32,6 +34,23 @@ const CLONE_POLL_TIMEOUT_MS = 20 * 60 * 1000;
 const CLONE_POLL_INITIAL_INTERVAL_MS = 1_000;
 /** Maximum interval between clone status polls. */
 const CLONE_POLL_MAX_INTERVAL_MS = 5_000;
+
+interface CloneResponseBody {
+	ok: boolean;
+	status?: string;
+	slug?: string;
+	sha?: string;
+	worktree?: string;
+	error?: string;
+	errorType?: ErrorType;
+	elapsedMs?: number;
+}
+
+function sandboxCloneError(body: CloneResponseBody, fallbackMessage: string): MegasthenesError {
+	const errorType: ErrorType = body.errorType ?? "clone_failed";
+	const message = body.error ? `Sandbox clone failed: ${body.error}` : fallbackMessage;
+	return new MegasthenesError(errorType, message, { isRetryable: errorType !== "invalid_commitish" });
+}
 
 function completeClone(
 	cloneSpan: Span | undefined,
@@ -125,18 +144,11 @@ export class SandboxClient {
 				signal: AbortSignal.timeout(30_000), // Starting a clone should be fast
 			});
 
-			const startBody = (await startRes.json()) as {
-				ok: boolean;
-				status?: string;
-				slug?: string;
-				sha?: string;
-				worktree?: string;
-				error?: string;
-			};
+			const startBody = (await startRes.json()) as CloneResponseBody;
 
 			if (!startBody.ok) {
 				this.logger.error("sandbox:client", new Error(`POST /clone → ${startRes.status}: ${startBody.error}`));
-				throw new Error(`Sandbox clone failed: ${startBody.error}`);
+				throw sandboxCloneError(startBody, `Sandbox clone failed (HTTP ${startRes.status})`);
 			}
 
 			// Already ready (cached)
@@ -190,17 +202,10 @@ export class SandboxClient {
 						signal: AbortSignal.timeout(30_000),
 					});
 
-					const retryBody = (await retryRes.json()) as {
-						ok: boolean;
-						status?: string;
-						slug?: string;
-						sha?: string;
-						worktree?: string;
-						error?: string;
-					};
+					const retryBody = (await retryRes.json()) as CloneResponseBody;
 
 					if (!retryBody.ok) {
-						throw new Error(`Sandbox clone failed on retry: ${retryBody.error}`);
+						throw sandboxCloneError(retryBody, `Sandbox clone failed on retry (HTTP ${retryRes.status})`);
 					}
 
 					// If the re-triggered clone is already cached/ready, return immediately
@@ -222,15 +227,7 @@ export class SandboxClient {
 					continue;
 				}
 
-				const statusBody = (await statusRes.json()) as {
-					ok: boolean;
-					status?: string;
-					slug?: string;
-					sha?: string;
-					worktree?: string;
-					error?: string;
-					elapsedMs?: number;
-				};
+				const statusBody = (await statusRes.json()) as CloneResponseBody;
 
 				if (statusBody.status !== lastStatus) {
 					cloneSpan?.addEvent("sandbox.clone.poll", {
@@ -260,7 +257,7 @@ export class SandboxClient {
 					const duration = Date.now() - t0;
 					cloneSpan?.addEvent("sandbox.clone.failed", { elapsed_ms: duration, slug });
 					this.logger.error("sandbox:client", new Error(`clone failed after ${duration}ms: ${statusBody.error}`));
-					throw new Error(`Sandbox clone failed: ${statusBody.error}`);
+					throw sandboxCloneError(statusBody, `Sandbox clone failed after ${duration}ms`);
 				}
 
 				// Still cloning — log progress
@@ -273,8 +270,13 @@ export class SandboxClient {
 			cloneSpan?.addEvent("sandbox.clone.timed_out", { timeout_ms: CLONE_POLL_TIMEOUT_MS, slug });
 			throw new Error(`Sandbox clone timed out after ${CLONE_POLL_TIMEOUT_MS / 1000}s for ${url}`);
 		} catch (error) {
-			const classified = classifyThrownError(error);
-			const errorType = classified.errorType === "network_error" ? "network_error" : "clone_failed";
+			let errorType: ErrorType;
+			if (error instanceof MegasthenesError) {
+				errorType = error.errorType;
+			} else {
+				const classified = classifyThrownError(error);
+				errorType = classified.errorType === "network_error" ? "network_error" : "clone_failed";
+			}
 			endChildSpanWithError(cloneSpan, errorType, error);
 			throw error;
 		}

--- a/src/sandbox/client.ts
+++ b/src/sandbox/client.ts
@@ -8,7 +8,7 @@
 import type { Span } from "@opentelemetry/api";
 import { classifyThrownError } from "../error-classification";
 import { type Logger, nullLogger } from "../logger";
-import { endSandboxCloneSpan, endSandboxCloneSpanWithError, startSandboxCloneSpan } from "../tracing";
+import { endChildSpan, endChildSpanWithError, startChildSpan } from "../tracing";
 
 /** Configuration for connecting to a sandbox worker. */
 export interface SandboxClientConfig {
@@ -95,7 +95,7 @@ export class SandboxClient {
 		const commit = commitish ?? "HEAD";
 		this.logger.debug("sandbox:client", `POST /clone url=${url} commitish=${commit}`);
 		const t0 = Date.now();
-		const cloneSpan = parentSpan ? startSandboxCloneSpan(parentSpan) : undefined;
+		const cloneSpan = parentSpan ? startChildSpan(parentSpan, "sandbox.clone") : undefined;
 
 		try {
 			cloneSpan?.addEvent("sandbox.clone.started", { url, commitish: commit });
@@ -131,7 +131,7 @@ export class SandboxClient {
 				);
 				cloneSpan?.addEvent("sandbox.clone.cached_ready", { elapsed_ms: duration });
 				onProgress?.("Repository ready");
-				endSandboxCloneSpan(cloneSpan, {
+				endChildSpan(cloneSpan, {
 					"megasthenes.sandbox.slug": startBody.slug,
 					"megasthenes.repo.commitish": startBody.sha,
 					"megasthenes.repo.local_path": startBody.worktree,
@@ -200,7 +200,7 @@ export class SandboxClient {
 						);
 						cloneSpan?.addEvent("sandbox.clone.ready", { elapsed_ms: duration, slug: retryBody.slug });
 						onProgress?.("Repository ready");
-						endSandboxCloneSpan(cloneSpan, {
+						endChildSpan(cloneSpan, {
 							"megasthenes.sandbox.slug": retryBody.slug,
 							"megasthenes.repo.commitish": retryBody.sha,
 							"megasthenes.repo.local_path": retryBody.worktree,
@@ -230,7 +230,7 @@ export class SandboxClient {
 					);
 					cloneSpan?.addEvent("sandbox.clone.ready", { elapsed_ms: duration, slug });
 					onProgress?.("Repository ready");
-					endSandboxCloneSpan(cloneSpan, {
+					endChildSpan(cloneSpan, {
 						"megasthenes.sandbox.slug": statusBody.slug ?? slug,
 						"megasthenes.repo.commitish": statusBody.sha,
 						"megasthenes.repo.local_path": statusBody.worktree,
@@ -257,7 +257,7 @@ export class SandboxClient {
 		} catch (error) {
 			const classified = classifyThrownError(error);
 			const errorType = classified.errorType === "network_error" ? "network_error" : "clone_failed";
-			endSandboxCloneSpanWithError(cloneSpan, errorType, error);
+			endChildSpanWithError(cloneSpan, errorType, error);
 			throw error;
 		}
 	}

--- a/src/sandbox/worker.ts
+++ b/src/sandbox/worker.ts
@@ -13,6 +13,7 @@
 
 import { closeSync, openSync } from "node:fs";
 import { buildToolCommand } from "../tool-commands";
+import type { ErrorType } from "../types";
 import { isolatedGitCommand, isolatedGitToolCommand, isolatedToolCommand } from "./isolation";
 
 /** Path to seccomp BPF filter that blocks network sockets (arch-specific) */
@@ -180,6 +181,8 @@ interface CloneJob {
 	worktree?: string;
 	/** Set when status = "failed" */
 	error?: string;
+	/** Set when status = "failed" — programmatic error classification. */
+	errorType?: ErrorType;
 	startedAt: number;
 	finishedAt?: number;
 }
@@ -265,6 +268,7 @@ async function executeClone(jobKey: string, url: string, commitish: string): Pro
 			if (exitCode !== 0) {
 				job.status = "failed";
 				job.error = friendlyCloneError(stderr, url);
+				job.errorType = "clone_failed";
 				job.finishedAt = Date.now();
 				console.error(`[sandbox:clone] clone failed for ${url}: ${stderr.slice(0, 200)}`);
 				return;
@@ -276,6 +280,7 @@ async function executeClone(jobKey: string, url: string, commitish: string): Pro
 		if (revParse.exitCode !== 0) {
 			job.status = "failed";
 			job.error = `Cannot resolve commitish "${commitish}": ${revParse.stderr.slice(0, 300)}`;
+			job.errorType = "invalid_commitish";
 			job.finishedAt = Date.now();
 			return;
 		}
@@ -290,6 +295,7 @@ async function executeClone(jobKey: string, url: string, commitish: string): Pro
 			if (wt.exitCode !== 0) {
 				job.status = "failed";
 				job.error = `git worktree add failed: ${wt.stderr.slice(0, 300)}`;
+				job.errorType = "clone_failed";
 				job.finishedAt = Date.now();
 				return;
 			}
@@ -304,6 +310,7 @@ async function executeClone(jobKey: string, url: string, commitish: string): Pro
 		const msg = err instanceof Error ? err.message : String(err);
 		job.status = "failed";
 		job.error = msg;
+		job.errorType = "clone_failed";
 		job.finishedAt = Date.now();
 		console.error(`[sandbox:clone] exception for ${url}: ${msg}`);
 	}
@@ -384,6 +391,7 @@ function handleCloneStatus(slug: string, commitish: string): Response {
 			ok: false,
 			status: "failed",
 			error: job.error,
+			errorType: job.errorType,
 		});
 	}
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -17,15 +17,19 @@ import { cleanupWorktree, type Repo } from "./forge";
 import { consoleLogger, type Logger } from "./logger";
 import { processStreamToEvents, type StreamFn } from "./stream-processor";
 import {
+	type AskTraceRoot,
 	endAskSpan,
 	endAskSpanWithError,
 	endCompactionSpan,
 	endCompactionSpanWithError,
 	endGenerationSpan,
 	endGenerationSpanWithError,
+	endRootAskSpan,
+	endRootAskSpanWithError,
 	endToolSpan,
 	endToolSpanWithError,
 	startAskSpan,
+	startAskTurnSpan,
 	startCompactionSpan,
 	startGenerationSpan,
 	startToolSpan,
@@ -138,8 +142,9 @@ export class Session {
 	#turns: TurnResult[] = [];
 	/** Messages snapshot at the end of each turn, keyed by turn ID. Used for afterTurn branching. */
 	#turnMessages = new Map<string, Message[]>();
+	#traceRoot?: AskTraceRoot;
 
-	constructor(repo: Repo, config: SessionConfig) {
+	constructor(repo: Repo, config: SessionConfig, traceRoot?: AskTraceRoot) {
 		this.id = randomUUID();
 		this.repo = repo;
 		this.config = {
@@ -151,6 +156,7 @@ export class Session {
 			compaction: config.compaction,
 		};
 		this.#config = config;
+		this.#traceRoot = traceRoot;
 		this.#logger = config.logger ?? consoleLogger;
 		this.#stream = (config.stream ?? stream) as StreamFn;
 		this.#streamSimple = (config.streamSimple ?? streamSimple) as StreamFn;
@@ -248,10 +254,20 @@ export class Session {
 		if (this.#closed) return;
 		this.#closed = true;
 
-		// Clean up worktree, log if it fails
-		const success = await cleanupWorktree(this.repo);
-		if (!success) {
-			this.#logger.error("Failed to cleanup worktree", { path: this.repo.localPath });
+		try {
+			// Clean up worktree, log if it fails
+			const success = await cleanupWorktree(this.repo);
+			if (!success) {
+				this.#logger.error("Failed to cleanup worktree", { path: this.repo.localPath });
+			}
+			if (this.#traceRoot?.rootSpan.isRecording()) {
+				endRootAskSpan(this.#traceRoot.rootSpan);
+			}
+		} catch (error) {
+			if (this.#traceRoot?.rootSpan.isRecording()) {
+				endRootAskSpanWithError(this.#traceRoot.rootSpan, "internal_error", error);
+			}
+			throw error;
 		}
 	}
 
@@ -313,15 +329,27 @@ export class Session {
 			const startedAt = Date.now();
 			yield { type: "turn_start", turnId, prompt, timestamp: startedAt };
 
-			// Start ask span after turn_start yield
-			askSpan = startAskSpan({
-				question: prompt,
-				sessionId: this.id,
-				repoUrl: this.repo.url,
-				commitish: this.repo.commitish,
-				model: modelId,
-				systemPrompt: this.#context.systemPrompt,
-			});
+			// Start a per-turn span after turn_start yield. Sessions created through
+			// Client.connect() attach this to the long-lived root ask span so connect
+			// and later turns share one end-to-end trace. Direct Session() tests keep
+			// the older per-turn root span behavior as a fallback.
+			askSpan = this.#traceRoot
+				? startAskTurnSpan(this.#traceRoot, {
+						question: prompt,
+						sessionId: this.id,
+						repoUrl: this.repo.url,
+						commitish: this.repo.commitish,
+						model: modelId,
+						systemPrompt: this.#context.systemPrompt,
+					})
+				: startAskSpan({
+						question: prompt,
+						sessionId: this.id,
+						repoUrl: this.repo.url,
+						commitish: this.repo.commitish,
+						model: modelId,
+						systemPrompt: this.#context.systemPrompt,
+					});
 
 			// Compaction (uses the turn model, not the session default)
 			const newQuestionMessage: Message = { role: "user", content: prompt, timestamp: Date.now() };

--- a/src/session.ts
+++ b/src/session.ts
@@ -25,7 +25,6 @@ import {
 	endGenerationSpan,
 	endGenerationSpanWithError,
 	endRootAskSpan,
-	endRootAskSpanWithError,
 	endToolSpan,
 	endToolSpanWithError,
 	startAskSpan,
@@ -254,20 +253,12 @@ export class Session {
 		if (this.#closed) return;
 		this.#closed = true;
 
-		try {
-			// Clean up worktree, log if it fails
-			const success = await cleanupWorktree(this.repo);
-			if (!success) {
-				this.#logger.error("Failed to cleanup worktree", { path: this.repo.localPath });
-			}
-			if (this.#traceRoot?.rootSpan.isRecording()) {
-				endRootAskSpan(this.#traceRoot.rootSpan);
-			}
-		} catch (error) {
-			if (this.#traceRoot?.rootSpan.isRecording()) {
-				endRootAskSpanWithError(this.#traceRoot.rootSpan, "internal_error", error);
-			}
-			throw error;
+		const success = await cleanupWorktree(this.repo);
+		if (!success) {
+			this.#logger.error("Failed to cleanup worktree", { path: this.repo.localPath });
+		}
+		if (this.#traceRoot) {
+			endRootAskSpan(this.#traceRoot.rootSpan);
 		}
 	}
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -362,7 +362,7 @@ export class Session {
 				// Check for abort before each iteration
 				if (options?.signal?.aborted) {
 					yield { type: "error", errorType: "aborted", message: "Aborted", isRetryable: false };
-					endAskSpanWithError(askSpan, "aborted");
+					endAskSpanWithError(askSpan, "aborted", "Aborted");
 					askSpanEnded = true;
 					yield {
 						type: "turn_end",
@@ -397,9 +397,13 @@ export class Session {
 				for await (const event of events) {
 					if (event.type === "error") {
 						hadError = true;
-						endGenerationSpanWithError(genSpan, event.message);
+						endGenerationSpanWithError(genSpan, {
+							errorType: event.errorType,
+							error: event.message,
+							fallbackMessage: event.message,
+						});
 						yield event;
-						endAskSpanWithError(askSpan, "generation_failed", event.message);
+						endAskSpanWithError(askSpan, event.errorType, event.message);
 						askSpanEnded = true;
 						yield {
 							type: "turn_end",
@@ -438,14 +442,19 @@ export class Session {
 					const responseText = textBlocks.map((b) => (b as { type: "text"; text: string }).text).join("\n");
 
 					if (!responseText.trim()) {
-						endGenerationSpanWithError(genSpan, "Empty response from API");
+						const emptyResponseMessage = "Model returned an empty response";
+						endGenerationSpanWithError(genSpan, {
+							errorType: "empty_response",
+							error: emptyResponseMessage,
+							fallbackMessage: emptyResponseMessage,
+						});
 						yield {
 							type: "error",
 							errorType: "empty_response",
-							message: "Model returned an empty response",
+							message: emptyResponseMessage,
 							isRetryable: true,
 						};
-						endAskSpanWithError(askSpan, "empty_response");
+						endAskSpanWithError(askSpan, "empty_response", emptyResponseMessage);
 						askSpanEnded = true;
 						yield {
 							type: "turn_end",
@@ -494,7 +503,7 @@ export class Session {
 				message: "Max iterations reached without a final answer.",
 				isRetryable: false,
 			};
-			endAskSpanWithError(askSpan, "max_iterations_reached");
+			endAskSpanWithError(askSpan, "max_iterations", "Max iterations reached without a final answer.");
 			askSpanEnded = true;
 			yield {
 				type: "turn_end",
@@ -504,7 +513,7 @@ export class Session {
 			};
 		} catch (error) {
 			if (askSpan && !askSpanEnded) {
-				endAskSpanWithError(askSpan, "unexpected_error", error);
+				endAskSpanWithError(askSpan, "internal_error", error);
 				askSpanEnded = true;
 			}
 			if (error instanceof MegasthenesError) throw error;

--- a/src/session.ts
+++ b/src/session.ts
@@ -245,9 +245,26 @@ export class Session {
 	/**
 	 * Close the session and clean up resources.
 	 *
-	 * This removes the git worktree associated with the session.
-	 * The session cannot be used after closing.
-	 * Safe to call multiple times.
+	 * **This MUST be called when the caller is done with the session.** The root
+	 * OTel "ask" span is started in `Client.connect()` and only ended here; if
+	 * `close()` is never called (early return, thrown `ask()`, caller forgets,
+	 * session is GC'd), the root span never terminates and the OTel SDK silently
+	 * drops the entire trace tree on shutdown — every turn, generation, and
+	 * tool span for this session is lost from your observability backend.
+	 *
+	 * Always pair `connect()` with `close()` via try/finally:
+	 *
+	 * ```ts
+	 * const session = await client.connect(config);
+	 * try {
+	 *   for await (const ev of session.ask("...")) { ... }
+	 * } finally {
+	 *   await session.close();
+	 * }
+	 * ```
+	 *
+	 * Also removes the git worktree associated with the session.
+	 * The session cannot be used after closing. Safe to call multiple times.
 	 */
 	async close(): Promise<void> {
 		if (this.#closed) return;

--- a/src/session.ts
+++ b/src/session.ts
@@ -425,11 +425,7 @@ export class Session {
 				for await (const event of events) {
 					if (event.type === "error") {
 						hadError = true;
-						endGenerationSpanWithError(genSpan, {
-							errorType: event.errorType,
-							error: event.message,
-							fallbackMessage: event.message,
-						});
+						endGenerationSpanWithError(genSpan, event.errorType, event.message);
 						yield event;
 						endAskSpanWithError(askSpan, event.errorType, event.message);
 						askSpanEnded = true;
@@ -471,11 +467,7 @@ export class Session {
 
 					if (!responseText.trim()) {
 						const emptyResponseMessage = "Model returned an empty response";
-						endGenerationSpanWithError(genSpan, {
-							errorType: "empty_response",
-							error: emptyResponseMessage,
-							fallbackMessage: emptyResponseMessage,
-						});
+						endGenerationSpanWithError(genSpan, "empty_response", emptyResponseMessage);
 						yield {
 							type: "error",
 							errorType: "empty_response",

--- a/src/tracing.ts
+++ b/src/tracing.ts
@@ -21,12 +21,17 @@
  *
  * @see https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/
  */
-import { context, type Span, SpanStatusCode, trace } from "@opentelemetry/api";
+import { context, type Context as OtelContext, type Span, SpanStatusCode, trace } from "@opentelemetry/api";
 import type { ErrorType } from "./types";
 
 const tracer = trace.getTracer("megasthenes");
 
-type TraceErrorStage = "ask" | "generation" | "compaction" | "tool_execution";
+type TraceErrorStage = "ask" | "generation" | "compaction" | "tool_execution" | "connect";
+
+export interface AskTraceRoot {
+	readonly rootSpan: Span;
+	readonly rootContext: OtelContext;
+}
 
 // =============================================================================
 // Attribute keys (GenAI semantic conventions + megasthenes extensions)
@@ -50,6 +55,10 @@ const ATTR = {
 	SESSION_ID: "megasthenes.session.id",
 	REPO_URL: "megasthenes.repo.url",
 	REPO_COMMITISH: "megasthenes.repo.commitish",
+	REQUESTED_COMMITISH: "megasthenes.repo.requested_commitish",
+	CONNECT_MODE: "megasthenes.connect.mode",
+	LOCAL_PATH: "megasthenes.repo.local_path",
+	CACHE_HIT: "megasthenes.connect.cache_hit",
 	ITERATION: "megasthenes.iteration",
 	TOTAL_ITERATIONS: "megasthenes.total_iterations",
 	TOTAL_TOOL_CALLS: "megasthenes.total_tool_calls",
@@ -163,7 +172,91 @@ function annotateErrorSpan(
 // Span helpers — thin wrappers that return OTel Span objects
 // =============================================================================
 
-/** Start the root span for an ask() call. */
+/** Start the long-lived root span for a connected session. */
+export function startRootAskSpan(params: {
+	repoUrl: string;
+	requestedCommitish: string;
+	mode: "local" | "sandbox";
+}): AskTraceRoot {
+	const rootSpan = tracer.startSpan("ask", {
+		attributes: {
+			[ATTR.REPO_URL]: params.repoUrl,
+			[ATTR.REQUESTED_COMMITISH]: params.requestedCommitish,
+			[ATTR.CONNECT_MODE]: params.mode,
+		},
+	});
+	return {
+		rootSpan,
+		rootContext: trace.setSpan(context.active(), rootSpan),
+	};
+}
+
+/** Add session metadata to the long-lived root ask span once the Session exists. */
+export function annotateRootAskSpan(
+	span: Span,
+	params: { sessionId: string; commitish: string; localPath?: string; cacheHit?: boolean },
+): void {
+	span.setAttributes({
+		[ATTR.SESSION_ID]: params.sessionId,
+		[ATTR.REPO_COMMITISH]: params.commitish,
+		...(params.localPath ? { [ATTR.LOCAL_PATH]: params.localPath } : {}),
+		...(params.cacheHit !== undefined ? { [ATTR.CACHE_HIT]: params.cacheHit } : {}),
+	});
+}
+
+/** End the long-lived root ask span. */
+export function endRootAskSpan(span: Span): void {
+	span.setStatus({ code: SpanStatusCode.OK });
+	span.end();
+}
+
+/** End the long-lived root ask span with a terminal error. */
+export function endRootAskSpanWithError(span: Span, errorType: ErrorType, error?: unknown): void {
+	annotateErrorSpan(span, {
+		error,
+		fallbackMessage: errorType,
+		errorType,
+		stage: "connect",
+	});
+	span.end();
+}
+
+/** Start the connect child span under the root ask span. */
+export function startConnectSpan(
+	parent: AskTraceRoot,
+	params: { repoUrl: string; requestedCommitish: string; mode: "local" | "sandbox" },
+): Span {
+	return tracer.startSpan(
+		"connect",
+		{
+			attributes: {
+				[ATTR.REPO_URL]: params.repoUrl,
+				[ATTR.REQUESTED_COMMITISH]: params.requestedCommitish,
+				[ATTR.CONNECT_MODE]: params.mode,
+			},
+		},
+		parent.rootContext,
+	);
+}
+
+/** End the connect span. */
+export function endConnectSpan(span: Span): void {
+	span.setStatus({ code: SpanStatusCode.OK });
+	span.end();
+}
+
+/** End the connect span with an error. */
+export function endConnectSpanWithError(span: Span, errorType: ErrorType, error?: unknown): void {
+	annotateErrorSpan(span, {
+		error,
+		fallbackMessage: errorType,
+		errorType,
+		stage: "connect",
+	});
+	span.end();
+}
+
+/** Start the root span for an ask() call when no session root exists. */
 export function startAskSpan(params: {
 	question: string;
 	sessionId: string;
@@ -192,7 +285,43 @@ export function startAskSpan(params: {
 	return span;
 }
 
-/** End the root ask span with final result metadata. */
+/** Start an ask-turn span under the long-lived root ask span. */
+export function startAskTurnSpan(
+	parent: AskTraceRoot,
+	params: {
+		question: string;
+		sessionId: string;
+		repoUrl: string;
+		commitish: string;
+		model: string;
+		systemPrompt?: string;
+	},
+): Span {
+	const span = tracer.startSpan(
+		"ask.turn",
+		{
+			attributes: {
+				[ATTR.OPERATION_NAME]: "chat",
+				[ATTR.REQUEST_MODEL]: params.model,
+				[ATTR.SESSION_ID]: params.sessionId,
+				[ATTR.REPO_URL]: params.repoUrl,
+				[ATTR.REPO_COMMITISH]: params.commitish,
+			},
+		},
+		parent.rootContext,
+	);
+	if (params.systemPrompt) {
+		span.addEvent(EVENT.SYSTEM_INSTRUCTIONS, {
+			content: params.systemPrompt,
+		});
+	}
+	span.addEvent(EVENT.INPUT_MESSAGES, {
+		content: params.question,
+	});
+	return span;
+}
+
+/** End an ask/ask.turn span with final result metadata. */
 export function endAskSpan(
 	span: Span,
 	result: {
@@ -211,15 +340,117 @@ export function endAskSpan(
 	span.end();
 }
 
-/** End the root ask span with an error. */
+/** End an ask/ask.turn span with an error. */
 export function endAskSpanWithError(span: Span, errorType: ErrorType, error?: unknown): void {
-	// Keep trace error.type aligned with the public ErrorType union so SDK
-	// consumers can query traces using the same values they see in TurnResult.
 	annotateErrorSpan(span, {
 		error,
 		fallbackMessage: errorType,
 		errorType,
 		stage: "ask",
+	});
+	span.end();
+}
+
+/** Start a repo clone/fetch child span. */
+export function startCloneOrFetchSpan(parentSpan: Span): Span {
+	const ctx = trace.setSpan(context.active(), parentSpan);
+	return tracer.startSpan("repo.clone_or_fetch", {}, ctx);
+}
+
+/** End the repo clone/fetch span. */
+export function endCloneOrFetchSpan(span: Span | undefined, attrs?: Record<string, unknown>): void {
+	if (!span) return;
+	if (attrs) span.setAttributes(attrs);
+	span.setStatus({ code: SpanStatusCode.OK });
+	span.end();
+}
+
+/** End the repo clone/fetch span with an error. */
+export function endCloneOrFetchSpanWithError(span: Span | undefined, errorType: ErrorType, error?: unknown): void {
+	if (!span) return;
+	annotateErrorSpan(span, {
+		error,
+		fallbackMessage: errorType,
+		errorType,
+		stage: "connect",
+	});
+	span.end();
+}
+
+/** Start a repo resolve-commitish child span. */
+export function startResolveCommitishSpan(parentSpan: Span): Span {
+	const ctx = trace.setSpan(context.active(), parentSpan);
+	return tracer.startSpan("repo.resolve_commitish", {}, ctx);
+}
+
+/** End the repo resolve-commitish span. */
+export function endResolveCommitishSpan(span: Span | undefined, attrs?: Record<string, unknown>): void {
+	if (!span) return;
+	if (attrs) span.setAttributes(attrs);
+	span.setStatus({ code: SpanStatusCode.OK });
+	span.end();
+}
+
+/** End the repo resolve-commitish span with an error. */
+export function endResolveCommitishSpanWithError(span: Span | undefined, errorType: ErrorType, error?: unknown): void {
+	if (!span) return;
+	annotateErrorSpan(span, {
+		error,
+		fallbackMessage: errorType,
+		errorType,
+		stage: "connect",
+	});
+	span.end();
+}
+
+/** Start a repo create-worktree child span. */
+export function startCreateWorktreeSpan(parentSpan: Span): Span {
+	const ctx = trace.setSpan(context.active(), parentSpan);
+	return tracer.startSpan("repo.create_worktree", {}, ctx);
+}
+
+/** End the repo create-worktree span. */
+export function endCreateWorktreeSpan(span: Span | undefined, attrs?: Record<string, unknown>): void {
+	if (!span) return;
+	if (attrs) span.setAttributes(attrs);
+	span.setStatus({ code: SpanStatusCode.OK });
+	span.end();
+}
+
+/** End the repo create-worktree span with an error. */
+export function endCreateWorktreeSpanWithError(span: Span | undefined, errorType: ErrorType, error?: unknown): void {
+	if (!span) return;
+	annotateErrorSpan(span, {
+		error,
+		fallbackMessage: errorType,
+		errorType,
+		stage: "connect",
+	});
+	span.end();
+}
+
+/** Start a sandbox clone child span. */
+export function startSandboxCloneSpan(parentSpan: Span): Span {
+	const ctx = trace.setSpan(context.active(), parentSpan);
+	return tracer.startSpan("sandbox.clone", {}, ctx);
+}
+
+/** End the sandbox clone span. */
+export function endSandboxCloneSpan(span: Span | undefined, attrs?: Record<string, unknown>): void {
+	if (!span) return;
+	if (attrs) span.setAttributes(attrs);
+	span.setStatus({ code: SpanStatusCode.OK });
+	span.end();
+}
+
+/** End the sandbox clone span with an error. */
+export function endSandboxCloneSpanWithError(span: Span | undefined, errorType: ErrorType, error?: unknown): void {
+	if (!span) return;
+	annotateErrorSpan(span, {
+		error,
+		fallbackMessage: errorType,
+		errorType,
+		stage: "connect",
 	});
 	span.end();
 }

--- a/src/tracing.ts
+++ b/src/tracing.ts
@@ -22,8 +22,11 @@
  * @see https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/
  */
 import { context, type Span, SpanStatusCode, trace } from "@opentelemetry/api";
+import type { ErrorType } from "./types";
 
 const tracer = trace.getTracer("megasthenes");
+
+type TraceErrorStage = "ask" | "generation" | "compaction" | "tool_execution";
 
 // =============================================================================
 // Attribute keys (GenAI semantic conventions + megasthenes extensions)
@@ -56,6 +59,7 @@ const ATTR = {
 	ERROR_TYPE: "error.type",
 	ERROR_NAME: "megasthenes.error.name",
 	ERROR_MESSAGE: "megasthenes.error.message",
+	ERROR_STAGE: "megasthenes.error.stage",
 } as const;
 
 // OTel event names (GenAI semantic conventions)
@@ -132,10 +136,19 @@ function normalizeErrorDetails(
 	return { name, message, exception };
 }
 
-function annotateErrorSpan(span: Span, error: unknown, fallbackMessage: string, errorType?: string) {
-	const details = normalizeErrorDetails(error, fallbackMessage);
+function annotateErrorSpan(
+	span: Span,
+	params: {
+		error: unknown;
+		fallbackMessage: string;
+		errorType?: ErrorType;
+		stage?: TraceErrorStage;
+	},
+) {
+	const details = normalizeErrorDetails(params.error, params.fallbackMessage);
 	span.setAttributes({
-		...(errorType ? { [ATTR.ERROR_TYPE]: errorType } : {}),
+		...(params.errorType ? { [ATTR.ERROR_TYPE]: params.errorType } : {}),
+		...(params.stage ? { [ATTR.ERROR_STAGE]: params.stage } : {}),
 		[ATTR.ERROR_NAME]: details.name,
 		[ATTR.ERROR_MESSAGE]: details.message,
 	});
@@ -199,8 +212,15 @@ export function endAskSpan(
 }
 
 /** End the root ask span with an error. */
-export function endAskSpanWithError(span: Span, errorType: string, error?: unknown): void {
-	annotateErrorSpan(span, error, errorType, errorType);
+export function endAskSpanWithError(span: Span, errorType: ErrorType, error?: unknown): void {
+	// Keep trace error.type aligned with the public ErrorType union so SDK
+	// consumers can query traces using the same values they see in TurnResult.
+	annotateErrorSpan(span, {
+		error,
+		fallbackMessage: errorType,
+		errorType,
+		stage: "ask",
+	});
 	span.end();
 }
 
@@ -226,7 +246,12 @@ export function endCompactionSpan(
 
 /** End the compaction span with an error. */
 export function endCompactionSpanWithError(span: Span, error: unknown): void {
-	annotateErrorSpan(span, error, "compaction failed", "compaction_failed");
+	annotateErrorSpan(span, {
+		error,
+		fallbackMessage: "compaction failed",
+		errorType: "internal_error",
+		stage: "compaction",
+	});
 	span.end();
 }
 
@@ -281,8 +306,16 @@ export function endGenerationSpan(
 }
 
 /** End a generation span with an error. */
-export function endGenerationSpanWithError(span: Span, error: unknown): void {
-	annotateErrorSpan(span, error, "generation failed", "generation_failed");
+export function endGenerationSpanWithError(
+	span: Span,
+	params: { errorType: ErrorType; error?: unknown; fallbackMessage?: string },
+): void {
+	annotateErrorSpan(span, {
+		error: params.error,
+		fallbackMessage: params.fallbackMessage ?? params.errorType,
+		errorType: params.errorType,
+		stage: "generation",
+	});
 	span.end();
 }
 
@@ -320,7 +353,12 @@ export function endToolSpan(span: Span, result: string): void {
 
 /** End a tool span with an error. */
 export function endToolSpanWithError(span: Span, error: unknown, result?: string): void {
-	const details = annotateErrorSpan(span, error, "tool execution failed", "tool_execution_failed");
+	const details = annotateErrorSpan(span, {
+		error,
+		fallbackMessage: "tool execution failed",
+		errorType: "internal_error",
+		stage: "tool_execution",
+	});
 	span.addEvent(EVENT.TOOL_CALL_RESULT, {
 		content: result ?? details.message,
 	});

--- a/src/tracing.ts
+++ b/src/tracing.ts
@@ -21,7 +21,14 @@
  *
  * @see https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/
  */
-import { context, type Context as OtelContext, type Span, SpanStatusCode, trace } from "@opentelemetry/api";
+import {
+	type Attributes,
+	context,
+	type Context as OtelContext,
+	type Span,
+	SpanStatusCode,
+	trace,
+} from "@opentelemetry/api";
 import type { ErrorType } from "./types";
 
 const tracer = trace.getTracer("megasthenes");
@@ -221,41 +228,6 @@ export function endRootAskSpanWithError(span: Span, errorType: ErrorType, error?
 	span.end();
 }
 
-/** Start the connect child span under the root ask span. */
-export function startConnectSpan(
-	parent: AskTraceRoot,
-	params: { repoUrl: string; requestedCommitish: string; mode: "local" | "sandbox" },
-): Span {
-	return tracer.startSpan(
-		"connect",
-		{
-			attributes: {
-				[ATTR.REPO_URL]: params.repoUrl,
-				[ATTR.REQUESTED_COMMITISH]: params.requestedCommitish,
-				[ATTR.CONNECT_MODE]: params.mode,
-			},
-		},
-		parent.rootContext,
-	);
-}
-
-/** End the connect span. */
-export function endConnectSpan(span: Span): void {
-	span.setStatus({ code: SpanStatusCode.OK });
-	span.end();
-}
-
-/** End the connect span with an error. */
-export function endConnectSpanWithError(span: Span, errorType: ErrorType, error?: unknown): void {
-	annotateErrorSpan(span, {
-		error,
-		fallbackMessage: errorType,
-		errorType,
-		stage: "connect",
-	});
-	span.end();
-}
-
 /** Start the root span for an ask() call when no session root exists. */
 export function startAskSpan(params: {
 	question: string;
@@ -351,23 +323,29 @@ export function endAskSpanWithError(span: Span, errorType: ErrorType, error?: un
 	span.end();
 }
 
-/** Start a repo clone/fetch child span. */
-export function startCloneOrFetchSpan(parentSpan: Span): Span {
-	const ctx = trace.setSpan(context.active(), parentSpan);
-	return tracer.startSpan("repo.clone_or_fetch", {}, ctx);
+/**
+ * Start a child span under the connect/clone hierarchy.
+ *
+ * Accepts either a Span (for sub-operation children) or an AskTraceRoot
+ * (for the top-level connect span). Optional start-time attributes are
+ * set on creation.
+ */
+export function startChildSpan(parent: Span | AskTraceRoot, name: string, attributes?: Attributes): Span {
+	const ctx = "rootContext" in parent ? parent.rootContext : trace.setSpan(context.active(), parent);
+	return tracer.startSpan(name, attributes ? { attributes } : {}, ctx);
 }
 
-/** End the repo clone/fetch span. */
-export function endCloneOrFetchSpan(span: Span | undefined, attrs?: Record<string, unknown>): void {
+/** End a connect-hierarchy child span with success, optionally setting final attributes. */
+export function endChildSpan(span: Span | undefined, attrs?: Attributes): void {
 	if (!span) return;
 	if (attrs) span.setAttributes(attrs);
 	span.setStatus({ code: SpanStatusCode.OK });
 	span.end();
 }
 
-/** End the repo clone/fetch span with an error. */
-export function endCloneOrFetchSpanWithError(span: Span | undefined, errorType: ErrorType, error?: unknown): void {
-	if (!span) return;
+/** End a connect-hierarchy child span with a terminal error. No-op if already ended. */
+export function endChildSpanWithError(span: Span | undefined, errorType: ErrorType, error?: unknown): void {
+	if (!span?.isRecording()) return;
 	annotateErrorSpan(span, {
 		error,
 		fallbackMessage: errorType,
@@ -377,82 +355,27 @@ export function endCloneOrFetchSpanWithError(span: Span | undefined, errorType: 
 	span.end();
 }
 
-/** Start a repo resolve-commitish child span. */
-export function startResolveCommitishSpan(parentSpan: Span): Span {
-	const ctx = trace.setSpan(context.active(), parentSpan);
-	return tracer.startSpan("repo.resolve_commitish", {}, ctx);
-}
-
-/** End the repo resolve-commitish span. */
-export function endResolveCommitishSpan(span: Span | undefined, attrs?: Record<string, unknown>): void {
-	if (!span) return;
-	if (attrs) span.setAttributes(attrs);
-	span.setStatus({ code: SpanStatusCode.OK });
-	span.end();
-}
-
-/** End the repo resolve-commitish span with an error. */
-export function endResolveCommitishSpanWithError(span: Span | undefined, errorType: ErrorType, error?: unknown): void {
-	if (!span) return;
-	annotateErrorSpan(span, {
-		error,
-		fallbackMessage: errorType,
-		errorType,
-		stage: "connect",
-	});
-	span.end();
-}
-
-/** Start a repo create-worktree child span. */
-export function startCreateWorktreeSpan(parentSpan: Span): Span {
-	const ctx = trace.setSpan(context.active(), parentSpan);
-	return tracer.startSpan("repo.create_worktree", {}, ctx);
-}
-
-/** End the repo create-worktree span. */
-export function endCreateWorktreeSpan(span: Span | undefined, attrs?: Record<string, unknown>): void {
-	if (!span) return;
-	if (attrs) span.setAttributes(attrs);
-	span.setStatus({ code: SpanStatusCode.OK });
-	span.end();
-}
-
-/** End the repo create-worktree span with an error. */
-export function endCreateWorktreeSpanWithError(span: Span | undefined, errorType: ErrorType, error?: unknown): void {
-	if (!span) return;
-	annotateErrorSpan(span, {
-		error,
-		fallbackMessage: errorType,
-		errorType,
-		stage: "connect",
-	});
-	span.end();
-}
-
-/** Start a sandbox clone child span. */
-export function startSandboxCloneSpan(parentSpan: Span): Span {
-	const ctx = trace.setSpan(context.active(), parentSpan);
-	return tracer.startSpan("sandbox.clone", {}, ctx);
-}
-
-/** End the sandbox clone span. */
-export function endSandboxCloneSpan(span: Span | undefined, attrs?: Record<string, unknown>): void {
-	if (!span) return;
-	if (attrs) span.setAttributes(attrs);
-	span.setStatus({ code: SpanStatusCode.OK });
-	span.end();
-}
-
-/** End the sandbox clone span with an error. */
-export function endSandboxCloneSpanWithError(span: Span | undefined, errorType: ErrorType, error?: unknown): void {
-	if (!span) return;
-	annotateErrorSpan(span, {
-		error,
-		fallbackMessage: errorType,
-		errorType,
-		stage: "connect",
-	});
-	span.end();
+/**
+ * Run `fn` under a connect-hierarchy child span.
+ *
+ * Starts the span (only if `parentSpan` is set), invokes `fn` with the span,
+ * and on thrown error ends the span with `errorType` before rethrowing. The
+ * caller is responsible for ending the span on success paths via `endChildSpan`
+ * — success-path attributes typically depend on inner control flow.
+ */
+export async function withChildSpan<T>(
+	parentSpan: Span | undefined,
+	name: string,
+	errorType: ErrorType,
+	fn: (span: Span | undefined) => Promise<T>,
+): Promise<T> {
+	const span = parentSpan ? startChildSpan(parentSpan, name) : undefined;
+	try {
+		return await fn(span);
+	} catch (error) {
+		endChildSpanWithError(span, errorType, error);
+		throw error;
+	}
 }
 
 /** Start a compaction child span. */
@@ -537,14 +460,11 @@ export function endGenerationSpan(
 }
 
 /** End a generation span with an error. */
-export function endGenerationSpanWithError(
-	span: Span,
-	params: { errorType: ErrorType; error?: unknown; fallbackMessage?: string },
-): void {
+export function endGenerationSpanWithError(span: Span, errorType: ErrorType, error?: unknown): void {
 	annotateErrorSpan(span, {
-		error: params.error,
-		fallbackMessage: params.fallbackMessage ?? params.errorType,
-		errorType: params.errorType,
+		error,
+		fallbackMessage: errorType,
+		errorType,
 		stage: "generation",
 	});
 	span.end();

--- a/src/tracing.ts
+++ b/src/tracing.ts
@@ -29,6 +29,7 @@ import {
 	SpanStatusCode,
 	trace,
 } from "@opentelemetry/api";
+import { MegasthenesError } from "./errors";
 import type { ErrorType } from "./types";
 
 const tracer = trace.getTracer("megasthenes");
@@ -359,20 +360,23 @@ export function endChildSpanWithError(span: Span | undefined, errorType: ErrorTy
  * Run `fn` under a connect-hierarchy child span.
  *
  * Starts the span (only if `parentSpan` is set), invokes `fn` with the span,
- * and on thrown error ends the span with `errorType` before rethrowing. The
- * caller is responsible for ending the span on success paths via `endChildSpan`
- * — success-path attributes typically depend on inner control flow.
+ * and on thrown error ends the span before rethrowing. If the thrown error is
+ * a `MegasthenesError`, its `errorType` is recorded on the span; otherwise the
+ * caller-supplied `fallbackErrorType` is used. The caller is responsible for
+ * ending the span on success paths via `endChildSpan` — success-path attributes
+ * typically depend on inner control flow.
  */
 export async function withChildSpan<T>(
 	parentSpan: Span | undefined,
 	name: string,
-	errorType: ErrorType,
+	fallbackErrorType: ErrorType,
 	fn: (span: Span | undefined) => Promise<T>,
 ): Promise<T> {
 	const span = parentSpan ? startChildSpan(parentSpan, name) : undefined;
 	try {
 		return await fn(span);
 	} catch (error) {
+		const errorType = error instanceof MegasthenesError ? error.errorType : fallbackErrorType;
 		endChildSpanWithError(span, errorType, error);
 		throw error;
 	}

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,7 @@ export type ErrorType =
 	| "network_error"
 	| "internal_error"
 	| "clone_failed"
+	| "fetch_failed"
 	| "invalid_commitish"
 	| "invalid_config";
 

--- a/test/forge.test.ts
+++ b/test/forge.test.ts
@@ -208,6 +208,18 @@ describe("forge", () => {
 			expect(readme2).toContain("Version 2");
 		});
 
+		test("reuses existing worktree for same commitish", async () => {
+			const repo1 = await connectRepo(repoUrl, { forge: "github", commitish: "v1.0" });
+			const repo2 = await connectRepo(repoUrl, { forge: "github", commitish: "v1.0" });
+
+			expect(repo1.localPath).toBe(repo2.localPath);
+			expect(repo1.cachePath).toBe(repo2.cachePath);
+			expect(repo1.commitish).toBe(repo2.commitish);
+
+			const readme = await readFile(join(repo2.localPath, "README.md"), "utf-8");
+			expect(readme).toContain("Version 1");
+		});
+
 		test("parallel calls with different commitish share cache", async () => {
 			const results = await Promise.all([
 				connectRepo(repoUrl, { forge: "github", commitish: "v1.0" }),

--- a/test/tracing.test.ts
+++ b/test/tracing.test.ts
@@ -12,6 +12,7 @@ import {
 import type { Repo } from "../src/forge";
 import { nullLogger } from "../src/logger";
 import { Session, type SessionConfig } from "../src/session";
+import type { Step, TurnResult } from "../src/types";
 
 // =============================================================================
 // In-memory OTel span recorder
@@ -256,13 +257,38 @@ function createToolCallStreamResult(
 	};
 }
 
-function createErrorStreamResult() {
+function makeAssistantErrorMessage(errorMessage: string) {
+	return {
+		role: "assistant" as const,
+		content: [],
+		usage: { input: 0, output: 0, totalTokens: 0, cacheRead: 0, cacheWrite: 0 },
+		timestamp: Date.now(),
+		api: "test",
+		provider: "test",
+		model: "test",
+		stopReason: "error",
+		errorMessage,
+	};
+}
+
+function createProviderErrorStreamResult(errorMessage = "Rate limit exceeded") {
 	return {
 		[Symbol.asyncIterator]: async function* () {
-			yield { type: "error", error: { errorMessage: "Rate limit exceeded" } };
+			yield { type: "error", error: makeAssistantErrorMessage(errorMessage) };
 		},
 		result: async () => {
 			throw new Error("Stream failed");
+		},
+	};
+}
+
+function createThrownErrorStreamResult(error: Error) {
+	return {
+		[Symbol.asyncIterator]: async function* () {
+			throw error;
+		},
+		result: async () => {
+			throw error;
 		},
 	};
 }
@@ -289,17 +315,42 @@ function createMockConfig(overrides?: Partial<SessionConfig>): SessionConfig {
 	};
 }
 
+function makeSeedTurn(
+	id: string,
+	prompt: string,
+	steps: Step[] = [{ type: "text", text: `Response to: ${prompt}`, role: "assistant" }],
+): TurnResult {
+	return {
+		id,
+		prompt,
+		steps,
+		usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 },
+		metadata: {
+			iterations: 1,
+			latencyMs: 100,
+			model: { provider: "test", id: "test-model" },
+			repo: { url: "https://github.com/test/repo", commitish: "abc123" },
+			config: { maxIterations: 10 },
+		},
+		error: null,
+		startedAt: Date.now() - 10000,
+		endedAt: Date.now() - 9000,
+	};
+}
+
 function expectSpanErrorDetails(
 	span: RecordedSpan | undefined,
 	{
 		errorType,
 		message,
+		stage,
 		name = "Error",
 		exceptionMessage = message,
 		exceptionCount = 1,
 	}: {
 		errorType: string;
 		message: string;
+		stage?: string;
 		name?: string;
 		exceptionMessage?: string;
 		exceptionCount?: number;
@@ -308,6 +359,9 @@ function expectSpanErrorDetails(
 	expect(span?.status.code).toBe(SpanStatusCode.ERROR);
 	expect(span?.status.message).toBe(message);
 	expect(span?.attributes["error.type"]).toBe(errorType);
+	if (stage !== undefined) {
+		expect(span?.attributes["megasthenes.error.stage"]).toBe(stage);
+	}
 	expect(span?.attributes["megasthenes.error.name"]).toBe(name);
 	expect(span?.attributes["megasthenes.error.message"]).toBe(message);
 	expect(span?.exceptions.length).toBe(exceptionCount);
@@ -471,16 +525,17 @@ describe("OTel tracing", () => {
 			expect(genSpans[1]?.attributes["megasthenes.iteration"]).toBe(2);
 		});
 
-		test("records exception on stream error", async () => {
-			const streamFn = (() => createErrorStreamResult()) as unknown as SessionConfig["stream"];
+		test("records provider_error on generation span for stream errors", async () => {
+			const streamFn = (() => createProviderErrorStreamResult()) as unknown as SessionConfig["stream"];
 			const session = new Session(createMockRepo(), createMockConfig({ stream: streamFn }));
 
 			await session.ask("Will fail").result();
 
 			const genSpan = recorder.getSpan("gen_ai.chat");
 			expectSpanErrorDetails(genSpan, {
-				errorType: "generation_failed",
+				errorType: "provider_error",
 				message: "API call failed: Rate limit exceeded",
+				stage: "generation",
 			});
 		});
 	});
@@ -566,11 +621,83 @@ describe("OTel tracing", () => {
 	});
 
 	// -------------------------------------------------------------------------
+	// Newer API flows
+	// -------------------------------------------------------------------------
+
+	describe("newer API flows", () => {
+		test("per-turn model override is reflected on ask and generation spans", async () => {
+			const overrideModel = { provider: "anthropic", id: "claude-sonnet-4-6" } as const;
+			const session = new Session(createMockRepo(), createMockConfig());
+
+			await session.ask("Override model", { model: overrideModel }).result();
+
+			const askSpan = recorder.getSpan("ask");
+			const genSpan = recorder.getSpan("gen_ai.chat");
+			expect(askSpan?.attributes["gen_ai.request.model"]).toBe("anthropic/claude-sonnet-4-6");
+			expect(genSpan?.attributes["gen_ai.request.model"]).toBe("anthropic/claude-sonnet-4-6");
+			expect(genSpan?.attributes["gen_ai.provider.name"]).toBe("anthropic");
+		});
+
+		test("restored initial turns are included in generation input messages", async () => {
+			const session = new Session(
+				createMockRepo(),
+				createMockConfig({
+					initialTurns: [
+						makeSeedTurn("seed-1", "Earlier question", [{ type: "text", text: "Earlier answer", role: "assistant" }]),
+					],
+				}),
+			);
+
+			await session.ask("New question").result();
+
+			const genSpan = recorder.getSpan("gen_ai.chat");
+			const inputEvent = genSpan?.events.find((e) => e.name === "gen_ai.input.messages");
+			expect(inputEvent?.attributes?.content).toContain("Earlier question");
+			expect(inputEvent?.attributes?.content).toContain("Earlier answer");
+			expect(inputEvent?.attributes?.content).toContain("New question");
+		});
+
+		test("afterTurn branching uses the requested turn snapshot in traced input messages", async () => {
+			const session = new Session(createMockRepo(), createMockConfig());
+			const firstTurn = await session.ask("First").result();
+			await session.ask("Second").result();
+
+			recorder.clear();
+			await session.ask("Branched", { afterTurn: firstTurn.id }).result();
+
+			const genSpan = recorder.getSpan("gen_ai.chat");
+			const inputEvent = genSpan?.events.find((e) => e.name === "gen_ai.input.messages");
+			expect(inputEvent?.attributes?.content).toContain("First");
+			expect(inputEvent?.attributes?.content).toContain("Branched");
+			expect(inputEvent?.attributes?.content).not.toContain("Second");
+		});
+
+		test("aborting between iterations records the public aborted error type on the ask span", async () => {
+			const controller = new AbortController();
+			const streamFn = (() => createToolCallStreamResult()) as unknown as SessionConfig["stream"];
+			const executeTool = async () => {
+				controller.abort();
+				return "tool result";
+			};
+			const session = new Session(createMockRepo(), createMockConfig({ stream: streamFn, executeTool }));
+
+			await session.ask("Abort me", { signal: controller.signal }).result();
+
+			const askSpan = recorder.getSpan("ask");
+			expectSpanErrorDetails(askSpan, {
+				errorType: "aborted",
+				message: "Aborted",
+				stage: "ask",
+			});
+		});
+	});
+
+	// -------------------------------------------------------------------------
 	// Error paths
 	// -------------------------------------------------------------------------
 
 	describe("error paths", () => {
-		test("max iterations ends ask span with error status", async () => {
+		test("max iterations records the public error type on the ask span", async () => {
 			const streamFn = (() => createToolCallStreamResult()) as unknown as SessionConfig["stream"];
 			const session = new Session(createMockRepo(), createMockConfig({ stream: streamFn, maxIterations: 2 }));
 
@@ -578,14 +705,14 @@ describe("OTel tracing", () => {
 
 			const askSpan = recorder.getSpan("ask");
 			expectSpanErrorDetails(askSpan, {
-				errorType: "max_iterations_reached",
-				message: "max_iterations_reached",
-				exceptionCount: 0,
+				errorType: "max_iterations",
+				message: "Max iterations reached without a final answer.",
+				stage: "ask",
 			});
 		});
 
-		test("API error ends both generation and ask spans properly", async () => {
-			const streamFn = (() => createErrorStreamResult()) as unknown as SessionConfig["stream"];
+		test("API errors use the same public error type on generation and ask spans", async () => {
+			const streamFn = (() => createProviderErrorStreamResult()) as unknown as SessionConfig["stream"];
 			const session = new Session(createMockRepo(), createMockConfig({ stream: streamFn }));
 
 			await session.ask("Fail").result();
@@ -593,15 +720,63 @@ describe("OTel tracing", () => {
 			const askSpan = recorder.getSpan("ask");
 			const genSpan = recorder.getSpan("gen_ai.chat");
 
-			// Generation ended with error
-			expect(genSpan?.status.code).toBe(SpanStatusCode.ERROR);
-			expect(genSpan?.attributes["error.type"]).toBe("generation_failed");
-			expect(genSpan?.attributes["megasthenes.error.message"]).toBe("API call failed: Rate limit exceeded");
+			expectSpanErrorDetails(genSpan, {
+				errorType: "provider_error",
+				message: "API call failed: Rate limit exceeded",
+				stage: "generation",
+			});
 			expect(genSpan?.ended).toBe(true);
 
-			// Ask span ended with error (stream error terminates the turn)
+			expectSpanErrorDetails(askSpan, {
+				errorType: "provider_error",
+				message: "API call failed: Rate limit exceeded",
+				stage: "ask",
+			});
 			expect(askSpan?.ended).toBe(true);
-			expect(askSpan?.status.code).toBe(SpanStatusCode.ERROR);
+		});
+
+		test("context overflow preserves the public provider error type in traces", async () => {
+			const streamFn = (() =>
+				createProviderErrorStreamResult(
+					"prompt is too long: 250000 tokens > 200000 maximum",
+				)) as unknown as SessionConfig["stream"];
+			const session = new Session(createMockRepo(), createMockConfig({ stream: streamFn }));
+
+			await session.ask("Overflow").result();
+
+			const askSpan = recorder.getSpan("ask");
+			const genSpan = recorder.getSpan("gen_ai.chat");
+			expectSpanErrorDetails(genSpan, {
+				errorType: "context_overflow",
+				message: "API call failed: prompt is too long: 250000 tokens > 200000 maximum",
+				stage: "generation",
+			});
+			expectSpanErrorDetails(askSpan, {
+				errorType: "context_overflow",
+				message: "API call failed: prompt is too long: 250000 tokens > 200000 maximum",
+				stage: "ask",
+			});
+		});
+
+		test("network failures preserve the public provider error type in traces", async () => {
+			const streamFn = (() =>
+				createThrownErrorStreamResult(new TypeError("fetch failed"))) as unknown as SessionConfig["stream"];
+			const session = new Session(createMockRepo(), createMockConfig({ stream: streamFn }));
+
+			await session.ask("Network").result();
+
+			const askSpan = recorder.getSpan("ask");
+			const genSpan = recorder.getSpan("gen_ai.chat");
+			expectSpanErrorDetails(genSpan, {
+				errorType: "network_error",
+				message: "API call failed: fetch failed",
+				stage: "generation",
+			});
+			expectSpanErrorDetails(askSpan, {
+				errorType: "network_error",
+				message: "API call failed: fetch failed",
+				stage: "ask",
+			});
 		});
 
 		test("tool execution error ends tool span with error and still lets ask complete", async () => {
@@ -625,8 +800,9 @@ describe("OTel tracing", () => {
 			// Tool span ended with error
 			const toolSpan = recorder.getSpans("gen_ai.execute_tool")[0];
 			expectSpanErrorDetails(toolSpan, {
-				errorType: "tool_execution_failed",
+				errorType: "internal_error",
 				message: "tool crashed",
+				stage: "tool_execution",
 			});
 			expect(toolSpan?.ended).toBe(true);
 			expect(toolSpan?.events.at(-1)?.name).toBe("gen_ai.tool.call.result");
@@ -638,7 +814,7 @@ describe("OTel tracing", () => {
 			expect(askSpan?.ended).toBe(true);
 		});
 
-		test("empty response records error on generation span", async () => {
+		test("empty response records the public error type on generation span", async () => {
 			const streamFn = (() => ({
 				[Symbol.asyncIterator]: async function* () {
 					yield { type: "text_delta", delta: "" };
@@ -660,13 +836,14 @@ describe("OTel tracing", () => {
 
 			const genSpan = recorder.getSpan("gen_ai.chat");
 			expectSpanErrorDetails(genSpan, {
-				errorType: "generation_failed",
-				message: "Empty response from API",
+				errorType: "empty_response",
+				message: "Model returned an empty response",
+				stage: "generation",
 			});
 			expect(genSpan?.ended).toBe(true);
 		});
 
-		test("empty final responses record structured details on the generation span", async () => {
+		test("empty final responses record structured public error details on the generation span", async () => {
 			const streamFn = (() => ({
 				[Symbol.asyncIterator]: async function* () {
 					yield { type: "text_delta", delta: "" };
@@ -686,12 +863,11 @@ describe("OTel tracing", () => {
 			const session = new Session(createMockRepo(), createMockConfig({ stream: streamFn }));
 			const _result = await session.ask("Return nothing").result();
 
-			// Empty response still completes (text step will be empty)
-
 			const genSpan = recorder.getSpan("gen_ai.chat");
 			expectSpanErrorDetails(genSpan, {
-				errorType: "generation_failed",
-				message: "Empty response from API",
+				errorType: "empty_response",
+				message: "Model returned an empty response",
+				stage: "generation",
 			});
 		});
 
@@ -707,7 +883,7 @@ describe("OTel tracing", () => {
 			expect(compSpan?.status.code).toBe(SpanStatusCode.OK);
 		});
 
-		test("unexpected ask failures record structured details on the ask span", async () => {
+		test("unexpected stream setup failures preserve the classified public error type", async () => {
 			const throwingStream = (() => {
 				throw new Error("stream setup exploded");
 			}) as unknown as SessionConfig["stream"];
@@ -722,8 +898,9 @@ describe("OTel tracing", () => {
 
 			const askSpan = recorder.getSpan("ask");
 			expectSpanErrorDetails(askSpan, {
-				errorType: "generation_failed",
+				errorType: "provider_error",
 				message: "API call failed: stream setup exploded",
+				stage: "ask",
 			});
 		});
 	});

--- a/test/tracing.test.ts
+++ b/test/tracing.test.ts
@@ -285,8 +285,12 @@ function createProviderErrorStreamResult(errorMessage = "Rate limit exceeded") {
 
 function createThrownErrorStreamResult(error: Error) {
 	return {
-		[Symbol.asyncIterator]: async function* () {
-			throw error;
+		[Symbol.asyncIterator]() {
+			return {
+				next: async () => {
+					throw error;
+				},
+			};
 		},
 		result: async () => {
 			throw error;

--- a/test/tracing.test.ts
+++ b/test/tracing.test.ts
@@ -13,7 +13,6 @@ import type { Repo } from "../src/forge";
 import { nullLogger } from "../src/logger";
 import { Session, type SessionConfig } from "../src/session";
 import { annotateRootAskSpan, startRootAskSpan } from "../src/tracing";
-import type { Step, TurnResult } from "../src/types";
 
 // =============================================================================
 // In-memory OTel span recorder
@@ -334,29 +333,6 @@ function createTracedSession(overrides?: Partial<SessionConfig>): Session {
 		localPath: repo.localPath,
 	});
 	return session;
-}
-
-function makeSeedTurn(
-	id: string,
-	prompt: string,
-	steps: Step[] = [{ type: "text", text: `Response to: ${prompt}`, role: "assistant" }],
-): TurnResult {
-	return {
-		id,
-		prompt,
-		steps,
-		usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 },
-		metadata: {
-			iterations: 1,
-			latencyMs: 100,
-			model: { provider: "test", id: "test-model" },
-			repo: { url: "https://github.com/test/repo", commitish: "abc123" },
-			config: { maxIterations: 10 },
-		},
-		error: null,
-		startedAt: Date.now() - 10000,
-		endedAt: Date.now() - 9000,
-	};
 }
 
 function expectSpanErrorDetails(
@@ -701,7 +677,22 @@ describe("OTel tracing", () => {
 				createMockRepo(),
 				createMockConfig({
 					initialTurns: [
-						makeSeedTurn("seed-1", "Earlier question", [{ type: "text", text: "Earlier answer", role: "assistant" }]),
+						{
+							id: "seed-1",
+							prompt: "Earlier question",
+							steps: [{ type: "text", text: "Earlier answer", role: "assistant" }],
+							usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 },
+							metadata: {
+								iterations: 1,
+								latencyMs: 100,
+								model: { provider: "test", id: "test-model" },
+								repo: { url: "https://github.com/test/repo", commitish: "abc123" },
+								config: { maxIterations: 10 },
+							},
+							error: null,
+							startedAt: Date.now() - 10000,
+							endedAt: Date.now() - 9000,
+						},
 					],
 				}),
 			);

--- a/test/tracing.test.ts
+++ b/test/tracing.test.ts
@@ -12,6 +12,7 @@ import {
 import type { Repo } from "../src/forge";
 import { nullLogger } from "../src/logger";
 import { Session, type SessionConfig } from "../src/session";
+import { annotateRootAskSpan, startRootAskSpan } from "../src/tracing";
 import type { Step, TurnResult } from "../src/types";
 
 // =============================================================================
@@ -315,6 +316,22 @@ function createMockConfig(overrides?: Partial<SessionConfig>): SessionConfig {
 	};
 }
 
+function createTracedSession(overrides?: Partial<SessionConfig>): Session {
+	const repo = createMockRepo();
+	const traceRoot = startRootAskSpan({
+		repoUrl: repo.url,
+		requestedCommitish: repo.commitish,
+		mode: "local",
+	});
+	const session = new Session(repo, createMockConfig(overrides), traceRoot);
+	annotateRootAskSpan(traceRoot.rootSpan, {
+		sessionId: session.id,
+		commitish: repo.commitish,
+		localPath: repo.localPath,
+	});
+	return session;
+}
+
 function makeSeedTurn(
 	id: string,
 	prompt: string,
@@ -438,6 +455,43 @@ describe("OTel tracing", () => {
 			const askSpans = recorder.getSpans("ask");
 			expect(askSpans.length).toBe(2);
 			expect(askSpans[0]?.attributes["megasthenes.session.id"]).toBe(askSpans[1]?.attributes["megasthenes.session.id"]);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// Session-root ask tracing
+	// -------------------------------------------------------------------------
+
+	describe("session-root ask tracing", () => {
+		test("connect-scoped root ask span stays open across turns and closes with the session", async () => {
+			const session = createTracedSession();
+
+			const rootBefore = recorder.getSpan("ask");
+			expect(rootBefore?.attributes["megasthenes.session.id"]).toBe(session.id);
+			expect(rootBefore?.ended).toBe(false);
+
+			await session.ask("Hello?").result();
+			const rootAfterTurn = recorder.getSpan("ask");
+			expect(rootAfterTurn?.ended).toBe(false);
+
+			await session.close();
+			const rootAfterClose = recorder.getSpan("ask");
+			expect(rootAfterClose?.ended).toBe(true);
+			expect(rootAfterClose?.status.code).toBe(SpanStatusCode.OK);
+		});
+
+		test("session-backed turns emit ask.turn spans under the long-lived ask root", async () => {
+			const session = createTracedSession();
+
+			await session.ask("First").result();
+			await session.ask("Second").result();
+
+			const askRoot = recorder.getSpan("ask");
+			const turnSpans = recorder.getSpans("ask.turn");
+			expect(turnSpans).toHaveLength(2);
+			expect(turnSpans[0]?.parentSpanId).toBe(askRoot?.spanId);
+			expect(turnSpans[1]?.parentSpanId).toBe(askRoot?.spanId);
+			expect(turnSpans[0]?.attributes["gen_ai.request.model"]).toBe("test-provider/test-model");
 		});
 	});
 

--- a/test/turns-to-messages.test.ts
+++ b/test/turns-to-messages.test.ts
@@ -389,8 +389,11 @@ describe("reconstructContext", () => {
 
 		const { messages, turnSnapshots } = reconstructContext([turn1, turn2]);
 
-		const snap1 = turnSnapshots.get("t1")!;
-		const snap2 = turnSnapshots.get("t2")!;
+		const snap1 = turnSnapshots.get("t1");
+		const snap2 = turnSnapshots.get("t2");
+		if (!snap1 || !snap2) {
+			throw new Error("expected reconstructed snapshots for both turns");
+		}
 
 		// Mutating snap1 should not affect snap2 or messages
 		snap1.push({ role: "user", content: "injected", timestamp: 0 });


### PR DESCRIPTION
## Summary
- align traced `error.type` values with the public `ErrorType` model
- add coverage for newer tracing flows such as model overrides, restored turns, branching, aborts, and classified provider errors
- trace repository setup under a single long-lived root `ask` span with `connect`, local clone/worktree spans, and sandbox clone spans
- update observability docs to reflect the session-root hierarchy, emitted attributes/events, and structured error semantics

## Testing
- bun test test/tracing.test.ts test/session.test.ts test/client.test.ts

## Notes
- no public API changes were introduced; the changes are internal to tracing and documentation
- `bunx tsc --noEmit` still reports pre-existing unrelated errors under `docs/` and `scripts/eval/`