### PR TITLE
fix(tools): validate LLM tool args against TypeBox schemas

### DIFF
--- a/src/sandbox/Containerfile
+++ b/src/sandbox/Containerfile
@@ -43,9 +43,16 @@ RUN ARCH=$(uname -m) \
 # Copy application files — layout must match import paths:
 #   worker.ts imports "../tool-commands" → /app/tool-commands.ts
 #   worker.ts imports "./isolation"      → /app/sandbox/isolation/index.ts
+#   tool-commands.ts imports "./tools"   → /app/tools.ts (for TypeBox-backed arg validation)
 COPY sandbox/worker.ts /app/sandbox/worker.ts
 COPY sandbox/isolation/index.ts /app/sandbox/isolation/index.ts
 COPY tool-commands.ts /app/tool-commands.ts
+COPY tools.ts /app/tools.ts
+
+# Install the TypeBox runtime used by tools.ts for argument validation.
+# pi-ai is imported type-only in tools.ts, so it doesn't need to be installed.
+WORKDIR /app
+RUN bun add @sinclair/typebox@0.34.49
 
 USER forge
 WORKDIR /home/forge

--- a/src/tool-commands.ts
+++ b/src/tool-commands.ts
@@ -1,15 +1,22 @@
 /**
- * Shared tool command builders.
+ * Shared tool command builders + schemas + argument validation.
  *
- * This module is the single source of truth for how tool arguments map to shell
- * commands. It has zero external dependencies so it can be deployed inside the
- * sandbox container alongside the worker.
+ * This module is the single source of truth for:
+ *   - how tool arguments are described to the LLM (TypeBox schemas),
+ *   - how those arguments are validated before dispatch,
+ *   - how validated arguments map to shell commands.
  *
- * Both the local executor (tools.ts) and the sandbox worker (worker.ts) import
- * from here, ensuring consistent parameter handling everywhere.
+ * Keeping these together enforces the invariant that you can't build a shell
+ * command without first validating inputs — the router calls `validateToolArgs`
+ * before any builder sees the data. The only external runtime dependency in
+ * this call graph is `@sinclair/typebox`, which the sandbox worker container
+ * also installs, so both the local executor (tools.ts) and the sandbox worker
+ * (worker.ts) can import from here.
  */
 
 import { isAbsolute, relative, resolve } from "node:path";
+import { type Static, type TSchema, Type } from "@sinclair/typebox";
+import { TypeCompiler } from "@sinclair/typebox/compiler";
 
 // =============================================================================
 // Constants
@@ -30,6 +37,97 @@ export const ALLOWED_GIT_SUBCOMMANDS = [
 ];
 
 // =============================================================================
+// Schemas (LLM-facing parameter definitions)
+// =============================================================================
+
+// TypeBox `Object` schemas default to allowing additional properties; we rely
+// on that behaviour so the LLM can pass extra fields without breaking the call
+// (unknown fields are simply ignored by the builders).
+
+export const rgSchema = Type.Object({
+	pattern: Type.String({ description: "The regex pattern to search for" }),
+	glob: Type.Optional(
+		Type.String({
+			description: "File glob pattern to filter files (e.g., '*.ts', '**/*.json')",
+		}),
+	),
+	max_count: Type.Optional(Type.Number({ description: "Max matching lines per file" })),
+	max_results: Type.Optional(
+		Type.Number({
+			description: "Max total matches (global), enforced via head",
+		}),
+	),
+	word: Type.Optional(Type.Boolean({ description: "Match whole words only (-w)" })),
+});
+
+export const fdSchema = Type.Object({
+	pattern: Type.String({
+		description: "The regex pattern to match file names against (use --glob for glob patterns)",
+	}),
+	type: Type.Optional(
+		Type.Union([Type.Literal("f"), Type.Literal("d"), Type.Literal("l"), Type.Literal("x")], {
+			description: "Filter by type: 'f' for files, 'd' for directories, 'l' for symlinks, 'x' for executables",
+		}),
+	),
+	extension: Type.Optional(
+		Type.String({
+			description: "Filter by file extension (e.g., 'ts', 'json'). Can be comma-separated for multiple extensions.",
+		}),
+	),
+	max_depth: Type.Optional(Type.Number({ description: "Maximum directory depth to search" })),
+	max_results: Type.Optional(Type.Number({ description: "Maximum number of results to return" })),
+	hidden: Type.Optional(Type.Boolean({ description: "Include hidden files and directories" })),
+	glob: Type.Optional(Type.Boolean({ description: "Use glob pattern instead of regex" })),
+	exclude: Type.Optional(
+		Type.String({
+			description: "Exclude entries matching this glob pattern (e.g., 'node_modules' or '*.pyc')",
+		}),
+	),
+	full_path: Type.Optional(
+		Type.Boolean({
+			description: "Match pattern against full path, not just filename",
+		}),
+	),
+});
+
+export const lsSchema = Type.Object({
+	path: Type.Optional(
+		Type.String({
+			description: "Path to list, relative to repository root. Defaults to root if not specified.",
+		}),
+	),
+});
+
+export const readSchema = Type.Object({
+	path: Type.String({
+		description: "Path to the file, relative to repository root",
+	}),
+});
+
+export const gitSchema = Type.Object({
+	command: Type.Union(
+		[
+			Type.Literal("log"),
+			Type.Literal("show"),
+			Type.Literal("blame"),
+			Type.Literal("diff"),
+			Type.Literal("shortlog"),
+			Type.Literal("describe"),
+			Type.Literal("rev-parse"),
+			Type.Literal("ls-tree"),
+			Type.Literal("cat-file"),
+		],
+		{ description: "The git subcommand to run" },
+	),
+	args: Type.Optional(
+		Type.Array(Type.String(), {
+			description:
+				"Additional arguments for the git command (e.g., ['--oneline', '-n', '10'] for log, or ['HEAD~5..HEAD'] for diff)",
+		}),
+	),
+});
+
+// =============================================================================
 // Types
 // =============================================================================
 
@@ -37,6 +135,76 @@ export const ALLOWED_GIT_SUBCOMMANDS = [
 export type ToolCommand =
 	| { ok: true; cmd: string[]; postProcess?: (stdout: string) => string }
 	| { ok: false; error: string };
+
+// Argument shapes derived from the TypeBox schemas. Deriving them here (rather
+// than maintaining parallel `interface`s) eliminates drift: adding a field to
+// a schema automatically flows through to the corresponding builder's param
+// type.
+type RgArgs = Static<typeof rgSchema>;
+type FdArgs = Static<typeof fdSchema>;
+type LsArgs = Static<typeof lsSchema>;
+type ReadArgs = Static<typeof readSchema>;
+type GitArgs = Static<typeof gitSchema>;
+
+type ToolName = "rg" | "fd" | "ls" | "read" | "git";
+
+type ArgsFor<N extends ToolName> = {
+	rg: RgArgs;
+	fd: FdArgs;
+	ls: LsArgs;
+	read: ReadArgs;
+	git: GitArgs;
+}[N];
+
+// =============================================================================
+// Argument validation
+// =============================================================================
+
+// Compile each schema once at module load — TypeCompiler is ~100x faster than
+// Value.Check on the hot path, and tool calls run on every LLM turn.
+const validators: Record<ToolName, ReturnType<typeof TypeCompiler.Compile<TSchema>>> = {
+	rg: TypeCompiler.Compile(rgSchema),
+	fd: TypeCompiler.Compile(fdSchema),
+	ls: TypeCompiler.Compile(lsSchema),
+	read: TypeCompiler.Compile(readSchema),
+	git: TypeCompiler.Compile(gitSchema),
+};
+
+/** Format the first TypeBox error as an actionable, human-readable message. */
+function formatValidationError(toolName: string, firstError: { path: string; message: string } | undefined): string {
+	if (!firstError) return `${toolName}: invalid arguments`;
+	// path looks like "/pattern" or "/args/0"; strip the leading slash for readability.
+	const field = firstError.path.replace(/^\//, "") || "(root)";
+	return `${toolName}: ${firstError.message} at '${field}'`;
+}
+
+/**
+ * Validate tool arguments against the tool's TypeBox schema.
+ * Returns a discriminated union so callers can surface errors without throwing.
+ *
+ * The return type is generic over the tool name so the router can dispatch to
+ * per-tool builders without `as` casts at the call site. The single cast inside
+ * this function is localized to the point where `validator.Check` has just
+ * succeeded — TypeBox's `Check` narrows the input at the value level, but the
+ * stringly-keyed `validators` lookup erases the per-tool schema type.
+ *
+ * Extra/unknown properties are ignored (TypeBox default): schemas do not set
+ * `additionalProperties: false`, so the LLM may pass extras without failing.
+ */
+export function validateToolArgs<N extends ToolName>(
+	toolName: N,
+	args: unknown,
+): { ok: true; value: ArgsFor<N> } | { ok: false; error: string } {
+	const validator = validators[toolName];
+	if (validator.Check(args)) {
+		// `Check` is a type guard at the value level, but the stringly-keyed
+		// `validators` lookup erases the per-tool schema type — hence the cast.
+		// It's localized to this one post-validation point vs. one per call site.
+		return { ok: true, value: args as ArgsFor<N> };
+	}
+	const [firstError] = [...validator.Errors(args)];
+	return { ok: false, error: formatValidationError(toolName, firstError) };
+}
 
 // =============================================================================
 // Helpers
@@ -59,21 +227,17 @@ export function validateProjectPath(rootPath: string, userPath: string): string 
 // Command Builders
 // =============================================================================
 
-export function buildRgCommand(args: Record<string, unknown>): string[] {
-	const pattern = args.pattern as string;
-	const glob = args.glob as string | undefined;
-	const maxCount = (args.max_count as number | undefined) ?? RG_MAX_MATCHES_PER_FILE;
-	const word = args.word as boolean | undefined;
-
-	const cmd = ["rg", "--line-number", "--max-count", String(maxCount), pattern];
-	if (glob) cmd.push("--glob", glob);
-	if (word) cmd.push("-w");
+export function buildRgCommand(args: RgArgs): string[] {
+	const maxCount = args.max_count ?? RG_MAX_MATCHES_PER_FILE;
+	const cmd = ["rg", "--line-number", "--max-count", String(maxCount), args.pattern];
+	if (args.glob) cmd.push("--glob", args.glob);
+	if (args.word) cmd.push("-w");
 	return cmd;
 }
 
-function buildRg(args: Record<string, unknown>): ToolCommand {
-	const maxResults = args.max_results as number | undefined;
+function buildRg(args: RgArgs): ToolCommand {
 	const cmd = buildRgCommand(args);
+	const maxResults = args.max_results;
 
 	const postProcess = maxResults
 		? (output: string) => {
@@ -86,43 +250,33 @@ function buildRg(args: Record<string, unknown>): ToolCommand {
 	return { ok: true, cmd, postProcess };
 }
 
-export function buildFdCommand(args: Record<string, unknown>): string[] {
-	const pattern = args.pattern as string;
-	const type = args.type as "f" | "d" | "l" | "x" | undefined;
-	const extension = args.extension as string | undefined;
-	const maxDepth = args.max_depth as number | undefined;
-	const maxResults = args.max_results as number | undefined;
-	const hidden = args.hidden as boolean | undefined;
-	const glob = args.glob as boolean | undefined;
-	const exclude = args.exclude as string | undefined;
-	const fullPath = args.full_path as boolean | undefined;
-
+export function buildFdCommand(args: FdArgs): string[] {
 	const cmd = ["fd"];
 
-	if (type) cmd.push("--type", type);
-	if (hidden) cmd.push("--hidden");
-	if (glob) cmd.push("--glob");
-	if (fullPath) cmd.push("--full-path");
-	if (maxDepth !== undefined) cmd.push("--max-depth", String(maxDepth));
-	if (maxResults !== undefined) cmd.push("--max-results", String(maxResults));
-	if (exclude) cmd.push("--exclude", exclude);
+	if (args.type) cmd.push("--type", args.type);
+	if (args.hidden) cmd.push("--hidden");
+	if (args.glob) cmd.push("--glob");
+	if (args.full_path) cmd.push("--full-path");
+	if (args.max_depth !== undefined) cmd.push("--max-depth", String(args.max_depth));
+	if (args.max_results !== undefined) cmd.push("--max-results", String(args.max_results));
+	if (args.exclude) cmd.push("--exclude", args.exclude);
 
-	if (extension) {
-		for (const ext of extension.split(",").map((e) => e.trim())) {
+	if (args.extension) {
+		for (const ext of args.extension.split(",").map((e) => e.trim())) {
 			cmd.push("--extension", ext);
 		}
 	}
 
-	cmd.push(pattern);
+	cmd.push(args.pattern);
 	return cmd;
 }
 
-function buildFd(args: Record<string, unknown>): ToolCommand {
+function buildFd(args: FdArgs): ToolCommand {
 	return { ok: true, cmd: buildFdCommand(args) };
 }
 
-function buildLs(args: Record<string, unknown>, cwd: string): ToolCommand {
-	const path = (args.path as string | undefined) || ".";
+function buildLs(args: LsArgs, cwd: string): ToolCommand {
+	const path = args.path || ".";
 	const fullPath = validateProjectPath(cwd, path);
 	if (!fullPath) {
 		return { ok: false, error: `Error: invalid project path: ${path}` };
@@ -130,34 +284,32 @@ function buildLs(args: Record<string, unknown>, cwd: string): ToolCommand {
 	return { ok: true, cmd: ["ls", "-la", fullPath] };
 }
 
-function buildRead(args: Record<string, unknown>, cwd: string): ToolCommand {
-	const filePath = args.path as string;
-	const fullPath = validateProjectPath(cwd, filePath);
+function buildRead(args: ReadArgs, cwd: string): ToolCommand {
+	const fullPath = validateProjectPath(cwd, args.path);
 	if (!fullPath) {
-		return { ok: false, error: `Error: invalid project path: ${filePath}` };
+		return { ok: false, error: `Error: invalid project path: ${args.path}` };
 	}
 	return {
 		ok: true,
 		cmd: ["cat", "-n", fullPath],
 		postProcess: (output) => {
 			if (output.startsWith("Error")) return output;
-			return `[File: ${filePath}]\n\n${output}`;
+			return `[File: ${args.path}]\n\n${output}`;
 		},
 	};
 }
 
-function buildGit(args: Record<string, unknown>): ToolCommand {
-	const command = args.command as string;
-	const gitArgs = (args.args as string[]) || [];
+function buildGit(args: GitArgs): ToolCommand {
+	const gitArgs = args.args ?? [];
 
-	if (!ALLOWED_GIT_SUBCOMMANDS.includes(command)) {
+	if (!ALLOWED_GIT_SUBCOMMANDS.includes(args.command)) {
 		return {
 			ok: false,
-			error: `git subcommand not allowed: ${command}. Allowed: ${ALLOWED_GIT_SUBCOMMANDS.join(", ")}`,
+			error: `git subcommand not allowed: ${args.command}. Allowed: ${ALLOWED_GIT_SUBCOMMANDS.join(", ")}`,
 		};
 	}
 
-	return { ok: true, cmd: ["git", command, ...gitArgs] };
+	return { ok: true, cmd: ["git", args.command, ...gitArgs] };
 }
 
 // =============================================================================
@@ -167,22 +319,38 @@ function buildGit(args: Record<string, unknown>): ToolCommand {
 /**
  * Build the shell command for a tool invocation.
  *
- * Returns a runnable command array plus optional post-processing,
- * or a validation error. The caller is responsible for actually
- * executing the command (locally via Bun.spawn, or in a sandbox via bwrap).
+ * Validates `args` against the tool's TypeBox schema BEFORE the builder touches
+ * them — a missing `pattern` returns a clean validation error instead of being
+ * spliced into argv as `undefined`. Returns a runnable command array plus
+ * optional post-processing, or a validation error. The caller is responsible
+ * for actually executing the command (locally via Bun.spawn, or in a sandbox
+ * via bwrap).
  */
 export function buildToolCommand(name: string, args: Record<string, unknown>, cwd: string): ToolCommand {
+	// Dispatch on the string first so each case narrows `name` to a literal
+	// `ToolName`; then the generic `validateToolArgs<N>` return type is
+	// precisely `ArgsFor<N>`, and the builder calls need no casts.
 	switch (name) {
-		case "rg":
-			return buildRg(args);
-		case "fd":
-			return buildFd(args);
-		case "ls":
-			return buildLs(args, cwd);
-		case "read":
-			return buildRead(args, cwd);
-		case "git":
-			return buildGit(args);
+		case "rg": {
+			const v = validateToolArgs("rg", args);
+			return v.ok ? buildRg(v.value) : { ok: false, error: v.error };
+		}
+		case "fd": {
+			const v = validateToolArgs("fd", args);
+			return v.ok ? buildFd(v.value) : { ok: false, error: v.error };
+		}
+		case "ls": {
+			const v = validateToolArgs("ls", args);
+			return v.ok ? buildLs(v.value, cwd) : { ok: false, error: v.error };
+		}
+		case "read": {
+			const v = validateToolArgs("read", args);
+			return v.ok ? buildRead(v.value, cwd) : { ok: false, error: v.error };
+		}
+		case "git": {
+			const v = validateToolArgs("git", args);
+			return v.ok ? buildGit(v.value) : { ok: false, error: v.error };
+		}
 		default:
 			return { ok: false, error: `Unknown tool: ${name}` };
 	}

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1,6 +1,5 @@
 import type { Tool } from "@mariozechner/pi-ai";
-import { Type } from "@sinclair/typebox";
-import { buildToolCommand } from "./tool-commands";
+import { buildToolCommand, fdSchema, gitSchema, lsSchema, readSchema, rgSchema } from "./tool-commands";
 
 /** External binaries that must be installed for local (non-sandbox) execution. */
 const REQUIRED_BINARIES = ["rg", "fd"] as const;
@@ -42,7 +41,7 @@ export async function validateRequiredTools(): Promise<string[]> {
 }
 
 // ---------------------------------------------------------------------------
-// Tool definitions (LLM-facing schema)
+// Tool definitions (LLM-facing catalog)
 // ---------------------------------------------------------------------------
 
 export const tools: Tool[] = [
@@ -50,102 +49,29 @@ export const tools: Tool[] = [
 		name: "rg",
 		description:
 			"Search for a pattern in files using ripgrep. Defaults to respecting .gitignore and hidden/binary files. Supports relevance filters and output limits.",
-		parameters: Type.Object({
-			pattern: Type.String({ description: "The regex pattern to search for" }),
-			glob: Type.Optional(
-				Type.String({
-					description: "File glob pattern to filter files (e.g., '*.ts', '**/*.json')",
-				}),
-			),
-			max_count: Type.Optional(Type.Number({ description: "Max matching lines per file" })),
-			max_results: Type.Optional(
-				Type.Number({
-					description: "Max total matches (global), enforced via head",
-				}),
-			),
-			word: Type.Optional(Type.Boolean({ description: "Match whole words only (-w)" })),
-		}),
+		parameters: rgSchema,
 	},
 	{
 		name: "fd",
 		description:
 			"Find files by name pattern using fd. Returns matching file paths. Defaults to respecting .gitignore and excluding hidden files. Supports relevant filters and output limits.",
-		parameters: Type.Object({
-			pattern: Type.String({
-				description: "The regex pattern to match file names against (use --glob for glob patterns)",
-			}),
-			type: Type.Optional(
-				Type.Union([Type.Literal("f"), Type.Literal("d"), Type.Literal("l"), Type.Literal("x")], {
-					description: "Filter by type: 'f' for files, 'd' for directories, 'l' for symlinks, 'x' for executables",
-				}),
-			),
-			extension: Type.Optional(
-				Type.String({
-					description: "Filter by file extension (e.g., 'ts', 'json'). Can be comma-separated for multiple extensions.",
-				}),
-			),
-			max_depth: Type.Optional(Type.Number({ description: "Maximum directory depth to search" })),
-			max_results: Type.Optional(Type.Number({ description: "Maximum number of results to return" })),
-			hidden: Type.Optional(Type.Boolean({ description: "Include hidden files and directories" })),
-			glob: Type.Optional(Type.Boolean({ description: "Use glob pattern instead of regex" })),
-			exclude: Type.Optional(
-				Type.String({
-					description: "Exclude entries matching this glob pattern (e.g., 'node_modules' or '*.pyc')",
-				}),
-			),
-			full_path: Type.Optional(
-				Type.Boolean({
-					description: "Match pattern against full path, not just filename",
-				}),
-			),
-		}),
+		parameters: fdSchema,
 	},
 	{
 		name: "ls",
 		description: "List files and directories in a given path.",
-		parameters: Type.Object({
-			path: Type.Optional(
-				Type.String({
-					description: "Path to list, relative to repository root. Defaults to root if not specified.",
-				}),
-			),
-		}),
+		parameters: lsSchema,
 	},
 	{
 		name: "read",
 		description: "Read the entire contents of a file. Each line is prefixed with its line number.",
-		parameters: Type.Object({
-			path: Type.String({
-				description: "Path to the file, relative to repository root",
-			}),
-		}),
+		parameters: readSchema,
 	},
 	{
 		name: "git",
 		description:
 			"Run read-only git commands to explore repository history. Allowed subcommands: log, show, blame, diff, shortlog, describe, rev-parse, ls-tree, cat-file.",
-		parameters: Type.Object({
-			command: Type.Union(
-				[
-					Type.Literal("log"),
-					Type.Literal("show"),
-					Type.Literal("blame"),
-					Type.Literal("diff"),
-					Type.Literal("shortlog"),
-					Type.Literal("describe"),
-					Type.Literal("rev-parse"),
-					Type.Literal("ls-tree"),
-					Type.Literal("cat-file"),
-				],
-				{ description: "The git subcommand to run" },
-			),
-			args: Type.Optional(
-				Type.Array(Type.String(), {
-					description:
-						"Additional arguments for the git command (e.g., ['--oneline', '-n', '10'] for log, or ['HEAD~5..HEAD'] for diff)",
-				}),
-			),
-		}),
+		parameters: gitSchema,
 	},
 ];
 

--- a/test/forge.test.ts
+++ b/test/forge.test.ts
@@ -408,7 +408,9 @@ describe("forge", () => {
 				.replace(/^\//, "")
 				.replace(/\.git$/, "")
 				.split("/");
-			const expectedSegment = join(parts[0], parts[1], "repo");
+			const [username, reponame] = parts;
+			if (!username || !reponame) throw new Error(`unexpected URL shape: ${url.pathname}`);
+			const expectedSegment = join(username, reponame, "repo");
 
 			expect(repo.cachePath).toContain(expectedSegment);
 		});
@@ -422,13 +424,14 @@ describe("forge", () => {
 				.replace(/^\//, "")
 				.replace(/\.git$/, "")
 				.split("/");
-			const parsedReponame = parts[1];
+			const [username, reponame] = parts;
+			if (!username || !reponame) throw new Error(`unexpected URL shape: ${url.pathname}`);
 
 			// The parsed reponame should not end with .git
-			expect(parsedReponame).not.toMatch(/\.git$/);
+			expect(reponame).not.toMatch(/\.git$/);
 
 			const home = homedir();
-			const expectedCachePath = resolve(home, ".megasthenes", "repos", parts[0], parsedReponame, "repo");
+			const expectedCachePath = resolve(home, ".megasthenes", "repos", username, reponame, "repo");
 			expect(repo.cachePath).toBe(expectedCachePath);
 		});
 	});

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { buildFdCommand, buildRgCommand } from "../src/tool-commands";
+import { buildFdCommand, buildRgCommand, buildToolCommand } from "../src/tool-commands";
 import { executeTool, overrideToolAvailability, validateRequiredTools } from "../src/tools";
 
 let repoDir: string;
@@ -582,5 +582,146 @@ describe("validateRequiredTools", () => {
 		overrideToolAvailability("fd", false);
 		const missing = await validateRequiredTools();
 		expect(missing).toEqual(["rg", "fd"]);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// buildToolCommand — schema validation
+// ---------------------------------------------------------------------------
+// Our TypeBox schemas do not set `additionalProperties: false`, so extra
+// unknown fields on the LLM's tool call are ignored rather than rejected.
+// Missing required fields and wrong types must fail fast with an actionable
+// error instead of becoming `undefined`/`NaN` in the spawned command.
+describe("buildToolCommand validation", () => {
+	const cwd = "/tmp";
+
+	test("rg: missing required pattern returns validation error", () => {
+		const result = buildToolCommand("rg", {}, cwd);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toContain("rg");
+			expect(result.error).toContain("pattern");
+		}
+	});
+
+	test("rg: pattern with wrong type returns validation error", () => {
+		const result = buildToolCommand("rg", { pattern: 123 }, cwd);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toContain("rg");
+			expect(result.error).toContain("pattern");
+		}
+	});
+
+	test("fd: missing required pattern returns validation error", () => {
+		const result = buildToolCommand("fd", {}, cwd);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toContain("fd");
+			expect(result.error).toContain("pattern");
+		}
+	});
+
+	test("read: missing required path returns validation error", () => {
+		const result = buildToolCommand("read", {}, cwd);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toContain("read");
+			expect(result.error).toContain("path");
+		}
+	});
+
+	test("git: missing required command returns validation error", () => {
+		const result = buildToolCommand("git", {}, cwd);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toContain("git");
+			expect(result.error).toContain("command");
+		}
+	});
+
+	test("git: command with disallowed literal value fails validation", () => {
+		// 'rm' is not one of the Type.Literal union members, so validation rejects it
+		// before the allowlist check in buildGit.
+		const result = buildToolCommand("git", { command: "rm" }, cwd);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toContain("git");
+		}
+	});
+
+	test("extra unexpected fields are ignored, not rejected", () => {
+		// TypeBox Object() defaults to additionalProperties:true, and we rely on that
+		// so the LLM can pass harmless extras without the call failing.
+		const result = buildToolCommand("rg", { pattern: "foo", unknown_field: "bar" }, cwd);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.cmd).toContain("foo");
+			expect(result.cmd).not.toContain("unknown_field");
+			expect(result.cmd).not.toContain("bar");
+		}
+	});
+
+	test("valid rg args produce the same command as before the refactor", () => {
+		const result = buildToolCommand("rg", { pattern: "foo", glob: "*.ts", max_count: 5, word: true }, cwd);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.cmd).toEqual(["rg", "--line-number", "--max-count", "5", "foo", "--glob", "*.ts", "-w"]);
+		}
+	});
+
+	test("valid fd args produce the expected command", () => {
+		const result = buildToolCommand(
+			"fd",
+			{ pattern: "foo", type: "f", extension: "ts", max_depth: 3, hidden: true },
+			cwd,
+		);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.cmd).toEqual(["fd", "--type", "f", "--hidden", "--max-depth", "3", "--extension", "ts", "foo"]);
+		}
+	});
+
+	test("valid git args produce the expected command", () => {
+		const result = buildToolCommand("git", { command: "log", args: ["--oneline", "-n", "5"] }, cwd);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.cmd).toEqual(["git", "log", "--oneline", "-n", "5"]);
+		}
+	});
+
+	test("valid ls args with no path default to '.'", () => {
+		const result = buildToolCommand("ls", {}, cwd);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.cmd[0]).toBe("ls");
+			expect(result.cmd[1]).toBe("-la");
+			expect(result.cmd[2]).toBe(cwd); // cwd resolved as '.'
+		}
+	});
+
+	test("fd: wrong type for max_depth (string instead of number) returns validation error", () => {
+		const result = buildToolCommand("fd", { pattern: "foo", max_depth: "deep" }, cwd);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toContain("fd");
+			expect(result.error).toContain("max_depth");
+		}
+	});
+
+	test("git: args field with wrong element type returns validation error", () => {
+		const result = buildToolCommand("git", { command: "log", args: [1, 2, 3] }, cwd);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toContain("git");
+		}
+	});
+
+	test("unknown tool name returns validation error (not a shell command)", () => {
+		const result = buildToolCommand("rmrf", { pattern: "foo" }, cwd);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toContain("Unknown tool");
+		}
 	});
 });


### PR DESCRIPTION
## Summary
- Tool builders in `src/tool-commands.ts` used `args.X as string` on LLM-provided fields; a missing required field became `undefined` spliced into `Bun.spawn` argv, surfacing as a confusing shell error. Validation now runs once at the boundary in `buildToolCommand` via TypeBox schemas compiled with `TypeCompiler.Compile`, returning a clean `ToolCommand` failure with the field name + expected type. Both local (`executeTool`) and sandbox (`src/sandbox/worker.ts`) paths route through this, so one validation point covers both.
- Consolidated schemas + validator + builders into `tool-commands.ts` so the dependency is one-way (`tools.ts → tool-commands.ts`), eliminating a circular import. Derived arg types via `Static<typeof schema>` (no hand-written interfaces to drift), and made `validateToolArgs` generic over the tool name so the router dispatches without `as unknown as X` double-casts.
- Container: `@sinclair/typebox` now installed in the worker image because the worker runs validation. Also fixed two pre-existing `noUncheckedIndexedAccess` errors in `test/forge.test.ts` as drive-by cleanup.

## Test plan
- [x] `bun run check` — biome clean
- [x] `bunx tsc --noEmit` — no errors in touched files (pre-existing `docs/node_modules`, `scripts/eval/` errors unchanged)
- [x] `bun test` — 352 pass / 0 fail, 843 expect() calls
- [x] New tests cover: missing required field (rg/fd/read/git), wrong type per tool, literal-union rejection, unknown tool name, extras-ignored semantics, and regression checks that valid args produce identical command arrays to before
- [ ] Deferred: pin TypeBox version in `src/sandbox/Containerfile` consistently with `package.json`'s `^0.34.48`

🤖 Generated with [Claude Code](https://claude.com/claude-code)