### PR TITLE
fix(session): drop as-unknown-as double-casts on pi-ai stopReason

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -498,7 +498,7 @@ export class Session {
 						outputTokens: response.usage?.output ?? 0,
 						cacheReadTokens: response.usage?.cacheRead ?? 0,
 						cacheCreationTokens: response.usage?.cacheWrite ?? 0,
-						stopReason: (response as unknown as { stopReason?: string }).stopReason,
+						stopReason: response.stopReason,
 					});
 					endAskSpan(askSpan, { toolCallCount: totalToolCalls, totalIterations: iterations, usage: totalUsage });
 					askSpanEnded = true;
@@ -519,7 +519,7 @@ export class Session {
 					outputTokens: response.usage?.output ?? 0,
 					cacheReadTokens: response.usage?.cacheRead ?? 0,
 					cacheCreationTokens: response.usage?.cacheWrite ?? 0,
-					stopReason: (response as unknown as { stopReason?: string }).stopReason,
+					stopReason: response.stopReason,
 				});
 				yield* this.#executeToolCalls(responseToolCalls, genSpan);
 			}


### PR DESCRIPTION
## Summary
- Closes #113.
- pi-ai's `AssistantMessage` declares `stopReason: StopReason` as a required, fully-typed field (`node_modules/@mariozechner/pi-ai/dist/types.d.ts:130`). Both `as unknown as { stopReason?: string }` casts in `src/session.ts` were redundant — and worse, they silently widened the narrow `StopReason` union (`"stop" | "length" | "toolUse" | "error" | "aborted"`) into `string | undefined`.
- Replaces both sites with direct `response.stopReason` access, matching the pattern already in use at `src/compaction.ts:571,600`. No helper introduced — there is no narrowing/augmentation responsibility to own, since the field is natively typed.

## Acceptance criteria from the issue
- [x] Zero `as unknown as` occurrences in `src/session.ts` (verified via `grep`).
- [x] Tracing attribute remains populated — since `stopReason` is a required (non-optional) field on `AssistantMessage`, it is always populated by pi-ai. The previous cast was falsely loosening it to optional.

## Test plan
- [x] `bun test` — 352 pass, 0 fail.
- [x] `bunx tsc --noEmit` — `src/` clean; only pre-existing unrelated errors in `scripts/eval/*.ts`.
- [x] `bunx biome check src/session.ts` — clean.
- [ ] Reviewer spot-check: confirm OTel span `stopReason` attribute is still emitted on a real model call (the previous cast masked whether this attribute was ever populated; the new code is stricter and will surface any real gap at compile time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)