### PR TITLE
refactor(compaction): replace Model<any> suppressions with Model<Api>

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,7 @@
 
 - **Use discriminated unions for results**: Prefer `{ ok: true; value: T } | { ok: false; error: E }` over exceptions for expected failures
 - **Avoid `any` and loose casts**: Create specific types for external/untyped data rather than using `as` assertions. Enforced by Biome (`suspicious/noExplicitAny`).
+- **Preserve literal hints in open string unions**: When a type should suggest known values but still accept arbitrary strings, write `Known | (string & {})` — not `Known | string`. The plain-`string` form collapses the literal arms during union simplification and kills autocomplete; intersecting with `{}` produces a structurally distinct type that blocks the collapse while still accepting every string at runtime. Same trick applies with `(number & {})` for numeric unions.
 - **Export types separately**: Use `type` imports for types that don't need runtime presence
 - **Exhaustiveness over switch discriminants**: Biome 2.4 ships no `useExhaustiveSwitchCases` rule, so we rely on TypeScript: `noFallthroughCasesInSwitch` is on, and authors should add a `default` arm that assigns the discriminant to a `const _: never = x` when they want a compile-time exhaustiveness check.
 

--- a/src/compaction.ts
+++ b/src/compaction.ts
@@ -7,10 +7,12 @@
  * 2. Generate a summary using an LLM
  * 3. Replace older messages with a summary message
  */
-import { completeSimple, type Message, type Model } from "@mariozechner/pi-ai";
+import { type Api, completeSimple, type Message, type Model } from "@mariozechner/pi-ai";
 import { COMPACTION_SETTINGS, type CompactionSettings } from "./config";
 
 export type { CompactionSettings };
+
+type AnyModel = Model<Api>;
 
 export function getCompactionSettings(): CompactionSettings {
 	return { ...COMPACTION_SETTINGS };
@@ -546,8 +548,7 @@ export interface CompactionResult {
  * Generate a summary of messages using an LLM.
  */
 async function generateSummary(
-	// biome-ignore lint/suspicious/noExplicitAny: Model requires generic parameter
-	model: Model<any>,
+	model: AnyModel,
 	messages: Message[],
 	previousSummary?: string,
 	_signal?: AbortSignal,
@@ -583,12 +584,7 @@ async function generateSummary(
 /**
  * Generate a summary for a turn prefix (when splitting a turn).
  */
-async function generateTurnPrefixSummary(
-	// biome-ignore lint/suspicious/noExplicitAny: Model requires generic parameter
-	model: Model<any>,
-	messages: Message[],
-	_signal?: AbortSignal,
-): Promise<string> {
+async function generateTurnPrefixSummary(model: AnyModel, messages: Message[], _signal?: AbortSignal): Promise<string> {
 	const conversationText = serializeConversation(messages);
 	const promptText = `<conversation>\n${conversationText}\n</conversation>\n\n${TURN_PREFIX_SUMMARIZATION_PROMPT}`;
 
@@ -618,8 +614,7 @@ function createSummaryWrapperMessage(summary: string): Message {
 }
 
 async function compactWithTokenIndex(
-	// biome-ignore lint/suspicious/noExplicitAny: Model requires generic parameter
-	model: Model<any>,
+	model: AnyModel,
 	messages: Message[],
 	previousSummary: string | undefined,
 	signal: AbortSignal | undefined,
@@ -694,8 +689,7 @@ async function compactWithTokenIndex(
  * Returns the summary and the messages to keep.
  */
 export async function compact(
-	// biome-ignore lint/suspicious/noExplicitAny: Model requires generic parameter
-	model: Model<any>,
+	model: AnyModel,
 	messages: Message[],
 	previousSummary?: string,
 	signal?: AbortSignal,
@@ -720,8 +714,7 @@ export interface MaybeCompactResult {
  * Returns the (possibly compacted) messages ready for the next ask.
  */
 export async function maybeCompact(
-	// biome-ignore lint/suspicious/noExplicitAny: Model requires generic parameter
-	model: Model<any>,
+	model: AnyModel,
 	messages: Message[],
 	previousSummary?: string,
 	signal?: AbortSignal,


### PR DESCRIPTION
## Summary

- Introduce `type AnyModel = Model<Api>` in `src/compaction.ts` and use it in the five sites that previously took `Model<any>`
- Remove the five repeated `biome-ignore lint/suspicious/noExplicitAny: Model requires generic parameter` suppressions — they are no longer needed
- Document the `Known | (string & {})` widening pattern in `AGENTS.md` so contributors reach for it before reaching for `any`

## Why `Model<Api>` instead of a centralized `Model<any>` alias

The issue presented two options: preferably `Model<Api>`, else a single centralized `Model<any>` with one justified suppression. `Model<Api>` fits cleanly here.

In `@mariozechner/pi-ai`:
- `export interface Model<TApi extends Api>` (types.d.ts)
- `export type Api = KnownApi | (string & {})` (types.d.ts)

`Api` is already the upper bound on `Model`'s generic parameter, so `Model<Api>` is the widest valid specialization — no escape hatch required. The SDK itself uses this exact pattern in `ApiStreamFunction = (model: Model<Api>, ...)` (api-registry.d.ts). Consumers of the local helpers (`completeSimple` et al.) are generic `<TApi extends Api>`, so passing `Model<Api>` binds `TApi = Api` — a valid, fully-typed call with no variance issue.

Net effect: same runtime surface as `Model<any>`, but every other field of `Model` (`id`, `cost`, `contextWindow`, `baseUrl`, …) stays type-checked instead of being poisoned by `any`.

## AGENTS.md addition

Added a bullet under **Type Design** explaining the `Known | (string & {})` trick — when to use it and why `Known | string` doesn't work (TypeScript collapses the literals during union simplification, killing autocomplete). Bundled into this PR because the pattern is what justifies choosing `Model<Api>` here; split it out if preferred.

## Test plan

- [x] `bun run check` — clean (biome alphabetized the new `type Api` import)
- [x] `bunx tsc --noEmit` — clean
- [x] `bun test` — 352 pass / 0 fail

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)