### PR TITLE
refactor(sandbox): use discriminated unions for clone job and response

### DIFF
--- a/src/sandbox/client.ts
+++ b/src/sandbox/client.ts
@@ -35,18 +35,25 @@ const CLONE_POLL_INITIAL_INTERVAL_MS = 1_000;
 /** Maximum interval between clone status polls. */
 const CLONE_POLL_MAX_INTERVAL_MS = 5_000;
 
-interface CloneResponseBody {
-	ok: boolean;
-	status?: string;
-	slug?: string;
-	sha?: string;
-	worktree?: string;
-	error?: string;
-	errorType?: ErrorType;
-	elapsedMs?: number;
+/** Body returned by the sandbox worker when it has a protocol status to report. */
+type CloneStatusBody =
+	| { ok: true; status: "cloning"; slug: string; elapsedMs?: number }
+	| { ok: true; status: "ready"; slug: string; sha: string; worktree: string }
+	| { ok: false; status: "failed"; error: string; errorType?: ErrorType };
+
+/** Envelope-level error body (e.g. 400 "url is required"), with no protocol status. */
+interface CloneEnvelopeError {
+	ok: false;
+	error: string;
 }
 
-function sandboxCloneError(body: CloneResponseBody, fallbackMessage: string): MegasthenesError {
+type CloneResponseBody = CloneStatusBody | CloneEnvelopeError;
+
+function isStatusBody(body: CloneResponseBody): body is CloneStatusBody {
+	return "status" in body;
+}
+
+function sandboxCloneError(body: { error?: string; errorType?: ErrorType }, fallbackMessage: string): MegasthenesError {
 	const errorType: ErrorType = body.errorType ?? "clone_failed";
 	const message = body.error ? `Sandbox clone failed: ${body.error}` : fallbackMessage;
 	return new MegasthenesError(errorType, message, {
@@ -58,7 +65,7 @@ type TriggerOutcome = ({ kind: "ready" } & CloneResult) | { kind: "pending"; slu
 
 type PollOutcome =
 	| ({ kind: "ready" } & CloneResult)
-	| { kind: "failed"; body: CloneResponseBody }
+	| { kind: "failed"; error: string; errorType?: ErrorType }
 	| { kind: "timed_out" };
 
 type OnEvent = (name: string, attrs?: Attributes) => void;
@@ -80,16 +87,20 @@ async function triggerClone(
 		signal: AbortSignal.timeout(30_000),
 	});
 	const body = (await res.json()) as CloneResponseBody;
-	if (!body.ok) {
-		throw sandboxCloneError(body, `${fallbackPrefix} (HTTP ${res.status})`);
+	const fallback = `${fallbackPrefix} (HTTP ${res.status})`;
+
+	if (!isStatusBody(body)) {
+		throw sandboxCloneError(body, fallback);
 	}
-	if (body.status === "ready" && body.slug && body.sha && body.worktree) {
-		return { kind: "ready", slug: body.slug, sha: body.sha, worktree: body.worktree };
+
+	switch (body.status) {
+		case "ready":
+			return { kind: "ready", slug: body.slug, sha: body.sha, worktree: body.worktree };
+		case "cloning":
+			return { kind: "pending", slug: body.slug };
+		case "failed":
+			throw sandboxCloneError(body, fallback);
 	}
-	if (!body.slug) {
-		throw new Error("Sandbox clone failed: no slug returned");
-	}
-	return { kind: "pending", slug: body.slug };
 }
 
 interface WaitArgs {
@@ -131,28 +142,33 @@ async function waitForClone(
 		}
 
 		const body = (await statusRes.json()) as CloneResponseBody;
+		if (!isStatusBody(body)) {
+			logger.warn("sandbox:client", `unexpected status response for ${args.slug}: ${body.error}`);
+			continue;
+		}
 
 		if (body.status !== lastStatus) {
 			args.onEvent("sandbox.clone.poll", {
 				elapsed_ms: Date.now() - args.startTime,
-				status: body.status ?? "unknown",
+				status: body.status,
 				previous_status: lastStatus ?? "none",
 			});
 			lastStatus = body.status;
 		}
 
-		if (body.status === "ready" && body.sha && body.worktree) {
-			return { kind: "ready", slug: body.slug ?? args.slug, sha: body.sha, worktree: body.worktree };
+		switch (body.status) {
+			case "ready":
+				return { kind: "ready", slug: body.slug, sha: body.sha, worktree: body.worktree };
+			case "failed":
+				return { kind: "failed", error: body.error, errorType: body.errorType };
+			case "cloning": {
+				const elapsed = body.elapsedMs ?? Date.now() - args.startTime;
+				const elapsedSec = Math.round(elapsed / 1000);
+				logger.debug("sandbox:client", `clone in progress for ${repo.url} (${elapsedSec}s elapsed)`);
+				args.onProgress?.(`Cloning repository… ${elapsedSec}s`);
+				break;
+			}
 		}
-
-		if (body.status === "failed") {
-			return { kind: "failed", body };
-		}
-
-		const elapsed = body.elapsedMs ?? Date.now() - args.startTime;
-		const elapsedSec = Math.round(elapsed / 1000);
-		logger.debug("sandbox:client", `clone in progress for ${repo.url} (${elapsedSec}s elapsed)`);
-		args.onProgress?.(`Cloning repository… ${elapsedSec}s`);
 	}
 
 	return { kind: "timed_out" };
@@ -275,8 +291,8 @@ export class SandboxClient {
 			if (outcome.kind === "failed") {
 				const duration = Date.now() - t0;
 				onEvent("sandbox.clone.failed", { elapsed_ms: duration, slug: trigger.slug });
-				this.logger.error("sandbox:client", new Error(`clone failed after ${duration}ms: ${outcome.body.error}`));
-				throw sandboxCloneError(outcome.body, `Sandbox clone failed after ${duration}ms`);
+				this.logger.error("sandbox:client", new Error(`clone failed after ${duration}ms: ${outcome.error}`));
+				throw sandboxCloneError(outcome, `Sandbox clone failed after ${duration}ms`);
 			}
 
 			onEvent("sandbox.clone.timed_out", { timeout_ms: CLONE_POLL_TIMEOUT_MS, slug: trigger.slug });

--- a/src/sandbox/worker.ts
+++ b/src/sandbox/worker.ts
@@ -170,22 +170,16 @@ async function runToolIsolated(
 // Async Clone State
 // =============================================================================
 
-type CloneStatus = "cloning" | "ready" | "failed";
-
-interface CloneJob {
-	status: CloneStatus;
+interface CloneJobBase {
 	url: string;
 	slug: string;
-	/** Set when status = "ready" */
-	sha?: string;
-	worktree?: string;
-	/** Set when status = "failed" */
-	error?: string;
-	/** Set when status = "failed" — programmatic error classification. */
-	errorType?: ErrorType;
 	startedAt: number;
-	finishedAt?: number;
 }
+
+type CloneJob =
+	| (CloneJobBase & { status: "cloning" })
+	| (CloneJobBase & { status: "ready"; sha: string; worktree: string; finishedAt: number })
+	| (CloneJobBase & { status: "failed"; error: string; errorType: ErrorType; finishedAt: number });
 
 /**
  * In-memory clone job tracker.
@@ -200,7 +194,7 @@ const JOB_TTL_MS = 10 * 60 * 1000;
 setInterval(() => {
 	const now = Date.now();
 	for (const [key, job] of cloneJobs) {
-		if (job.finishedAt && now - job.finishedAt > JOB_TTL_MS) {
+		if (job.status !== "cloning" && now - job.finishedAt > JOB_TTL_MS) {
 			cloneJobs.delete(key);
 		}
 	}
@@ -236,14 +230,18 @@ function friendlyCloneError(stderr: string, url: string): string {
 
 /**
  * Execute the clone/fetch + worktree setup in the background.
- * Updates the job entry in cloneJobs as it progresses.
+ * Replaces the job entry in cloneJobs as it transitions between states.
  */
 async function executeClone(jobKey: string, url: string, commitish: string): Promise<void> {
-	const job = cloneJobs.get(jobKey);
-	if (!job) return;
+	const started = cloneJobs.get(jobKey);
+	if (!started) return;
+	const base: CloneJobBase = { url: started.url, slug: started.slug, startedAt: started.startedAt };
 
-	const slug = job.slug;
-	const baseDir = repoDir(slug);
+	const markFailed = (error: string, errorType: ErrorType): void => {
+		cloneJobs.set(jobKey, { ...base, status: "failed", error, errorType, finishedAt: Date.now() });
+	};
+
+	const baseDir = repoDir(base.slug);
 	const bareDir = `${baseDir}/bare`;
 	const treesDir = `${baseDir}/trees`;
 
@@ -266,11 +264,8 @@ async function executeClone(jobKey: string, url: string, commitish: string): Pro
 				CLONE_TIMEOUT_MS,
 			);
 			if (exitCode !== 0) {
-				job.status = "failed";
-				job.error = friendlyCloneError(stderr, url);
-				job.errorType = "clone_failed";
-				job.finishedAt = Date.now();
 				console.error(`[sandbox:clone] clone failed for ${url}: ${stderr.slice(0, 200)}`);
+				markFailed(friendlyCloneError(stderr, url), "clone_failed");
 				return;
 			}
 		}
@@ -278,10 +273,7 @@ async function executeClone(jobKey: string, url: string, commitish: string): Pro
 		// Resolve commitish → SHA
 		const revParse = await runGitIsolated(["rev-parse", commitish], bareDir, baseDir);
 		if (revParse.exitCode !== 0) {
-			job.status = "failed";
-			job.error = `Cannot resolve commitish "${commitish}": ${revParse.stderr.slice(0, 300)}`;
-			job.errorType = "invalid_commitish";
-			job.finishedAt = Date.now();
+			markFailed(`Cannot resolve commitish "${commitish}": ${revParse.stderr.slice(0, 300)}`, "invalid_commitish");
 			return;
 		}
 		const sha = revParse.stdout.trim();
@@ -293,25 +285,16 @@ async function executeClone(jobKey: string, url: string, commitish: string): Pro
 		if (!worktreeExists) {
 			const wt = await runGitIsolated(["worktree", "add", worktree, sha], bareDir, baseDir);
 			if (wt.exitCode !== 0) {
-				job.status = "failed";
-				job.error = `git worktree add failed: ${wt.stderr.slice(0, 300)}`;
-				job.errorType = "clone_failed";
-				job.finishedAt = Date.now();
+				markFailed(`git worktree add failed: ${wt.stderr.slice(0, 300)}`, "clone_failed");
 				return;
 			}
 		}
 
-		job.status = "ready";
-		job.sha = sha;
-		job.worktree = worktree;
-		job.finishedAt = Date.now();
-		console.info(`[sandbox:clone] ready: ${url} → ${slug} @ ${shortSha} (${Date.now() - job.startedAt}ms)`);
+		cloneJobs.set(jobKey, { ...base, status: "ready", sha, worktree, finishedAt: Date.now() });
+		console.info(`[sandbox:clone] ready: ${url} → ${base.slug} @ ${shortSha} (${Date.now() - base.startedAt}ms)`);
 	} catch (err) {
 		const msg = err instanceof Error ? err.message : String(err);
-		job.status = "failed";
-		job.error = msg;
-		job.errorType = "clone_failed";
-		job.finishedAt = Date.now();
+		markFailed(msg, "clone_failed");
 		console.error(`[sandbox:clone] exception for ${url}: ${msg}`);
 	}
 }
@@ -334,19 +317,21 @@ function handleClone(body: CloneRequest): Response {
 	// Check for existing job
 	const existing = cloneJobs.get(jobKey);
 	if (existing) {
-		if (existing.status === "ready") {
-			return Response.json({
-				ok: true,
-				status: "ready",
-				slug,
-				sha: existing.sha,
-				worktree: existing.worktree,
-			});
+		switch (existing.status) {
+			case "ready":
+				return Response.json({
+					ok: true,
+					status: "ready",
+					slug,
+					sha: existing.sha,
+					worktree: existing.worktree,
+				});
+			case "cloning":
+				return Response.json({ ok: true, status: "cloning", slug });
+			case "failed":
+				// allow retry by falling through to create a new job
+				break;
 		}
-		if (existing.status === "cloning") {
-			return Response.json({ ok: true, status: "cloning", slug });
-		}
-		// "failed" — allow retry by falling through to create a new job
 	}
 
 	// Create new job
@@ -376,33 +361,30 @@ function handleCloneStatus(slug: string, commitish: string): Response {
 		return Response.json({ ok: false, error: "No clone job found for this repo" }, { status: 404 });
 	}
 
-	if (job.status === "ready") {
-		return Response.json({
-			ok: true,
-			status: "ready",
-			slug: job.slug,
-			sha: job.sha,
-			worktree: job.worktree,
-		});
+	switch (job.status) {
+		case "ready":
+			return Response.json({
+				ok: true,
+				status: "ready",
+				slug: job.slug,
+				sha: job.sha,
+				worktree: job.worktree,
+			});
+		case "failed":
+			return Response.json({
+				ok: false,
+				status: "failed",
+				error: job.error,
+				errorType: job.errorType,
+			});
+		case "cloning":
+			return Response.json({
+				ok: true,
+				status: "cloning",
+				slug: job.slug,
+				elapsedMs: Date.now() - job.startedAt,
+			});
 	}
-
-	if (job.status === "failed") {
-		return Response.json({
-			ok: false,
-			status: "failed",
-			error: job.error,
-			errorType: job.errorType,
-		});
-	}
-
-	// Still cloning
-	const elapsed = Date.now() - job.startedAt;
-	return Response.json({
-		ok: true,
-		status: "cloning",
-		slug: job.slug,
-		elapsedMs: elapsed,
-	});
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

- Split `CloneJob` in `src/sandbox/worker.ts` into a status-discriminated union (`cloning` / `ready` / `failed`) so `sha`, `worktree`, `error`, and `errorType` are only present on the variants that require them.
- `executeClone` now replaces the map entry on each state transition via a small `markFailed` helper, instead of mutating optional fields.
- Split `CloneResponseBody` in `src/sandbox/client.ts` into a protocol-level `CloneStatusBody` (discriminated on `status`) plus an envelope-level error body; `triggerClone`, `waitForClone`, and the worker's status handlers now switch on `status` and rely on TS narrowing.

## Why

The old shape allowed `{ status: "ready", sha: undefined }` or `{ status: "failed", error: undefined }` to compile, and `waitForClone` guarded on `sha`/`worktree` presence rather than the protocol state. Making invalid states unrepresentable means future changes can't silently regress the protocol invariants. Closes #115.

## Test plan

- [x] `bun test` — 351/352 pass (the one failure is an unrelated pre-existing seccomp integration test that times out without bwrap)
- [x] `bunx tsc --noEmit` — clean in `src/` and `test/`
- [x] `bun run check` (biome) — clean
- [x] Exercise sandbox clone path end-to-end against a running worker
🤖 Generated with [Claude Code](https://claude.com/claude-code)