### PR TITLE
fix(sandbox): validate worker HTTP request bodies at the boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+* Sandbox worker now validates `POST /clone` and `POST /tool` request bodies with TypeBox at the HTTP boundary. Malformed payloads (missing fields, wrong types, non-JSON) return `400 Bad Request` with an actionable error instead of bubbling up as opaque `500`s from `slugify` / `buildToolCommand`. (#123)
+
 ## [0.0.19] - 2026-04-13
 
 ### Added

--- a/src/sandbox/Containerfile
+++ b/src/sandbox/Containerfile
@@ -41,10 +41,12 @@ RUN ARCH=$(uname -m) \
     && mv /tmp/net-block.bpf /etc/seccomp/$ARCH/net-block.bpf
 
 # Copy application files — layout must match import paths:
-#   worker.ts imports "../tool-commands" → /app/tool-commands.ts
-#   worker.ts imports "./isolation"      → /app/sandbox/isolation/index.ts
-#   tool-commands.ts imports "./tools"   → /app/tools.ts (for TypeBox-backed arg validation)
+#   worker.ts imports "../tool-commands"     → /app/tool-commands.ts
+#   worker.ts imports "./isolation"          → /app/sandbox/isolation/index.ts
+#   worker.ts imports "./request-schemas"    → /app/sandbox/request-schemas.ts (HTTP body validation)
+#   tool-commands.ts imports "./tools"       → /app/tools.ts (for TypeBox-backed arg validation)
 COPY sandbox/worker.ts /app/sandbox/worker.ts
+COPY sandbox/request-schemas.ts /app/sandbox/request-schemas.ts
 COPY sandbox/isolation/index.ts /app/sandbox/isolation/index.ts
 COPY tool-commands.ts /app/tool-commands.ts
 COPY tools.ts /app/tools.ts

--- a/src/sandbox/request-schemas.ts
+++ b/src/sandbox/request-schemas.ts
@@ -1,0 +1,79 @@
+/**
+ * TypeBox schemas + validators for sandbox worker HTTP request bodies.
+ *
+ * Separated from worker.ts so tests can import the validators without
+ * triggering the top-level `Bun.serve` call that boots the HTTP server.
+ *
+ * Invariant: untrusted JSON should become trusted data exactly once, at
+ * the HTTP boundary. Handlers in worker.ts operate only on the `Static`
+ * types produced by these schemas — raw `req.json()` payloads must not be
+ * cast to request types directly.
+ */
+
+import { type Static, Type } from "@sinclair/typebox";
+import { TypeCompiler } from "@sinclair/typebox/compiler";
+
+// =============================================================================
+// Schemas
+// =============================================================================
+
+// `additionalProperties` is left at TypeBox's default (permissive) so that
+// sandbox clients can evolve their payloads without tripping the validator.
+// The fields we actually consume are the ones declared below.
+
+export const CloneRequestSchema = Type.Object({
+	url: Type.String({ minLength: 1, description: "Git repository URL to clone" }),
+	commitish: Type.Optional(
+		Type.String({ minLength: 1, description: "Branch, tag, or SHA to check out (defaults to HEAD)" }),
+	),
+});
+export type CloneRequest = Static<typeof CloneRequestSchema>;
+
+export const ToolRequestSchema = Type.Object({
+	slug: Type.String({ minLength: 1, description: "Repository slug returned by /clone" }),
+	sha: Type.String({ minLength: 1, description: "Resolved commit SHA to execute against" }),
+	name: Type.String({ minLength: 1, description: "Tool name (rg, fd, ls, read, git)" }),
+	// Tool-specific argument validation happens later in `buildToolCommand`; at
+	// the HTTP boundary we only assert that `args` is an object-shaped record.
+	args: Type.Record(Type.String(), Type.Unknown(), {
+		description: "Tool-specific arguments; validated against per-tool schemas downstream",
+	}),
+});
+export type ToolRequest = Static<typeof ToolRequestSchema>;
+
+// =============================================================================
+// Validation
+// =============================================================================
+
+// Compile once at module load. TypeCompiler is ~100x faster than `Value.Check`
+// and these validators run on every request.
+const cloneValidator = TypeCompiler.Compile(CloneRequestSchema);
+const toolValidator = TypeCompiler.Compile(ToolRequestSchema);
+
+export type ValidationResult<T> = { ok: true; value: T } | { ok: false; error: string };
+
+/** Format the first TypeBox error as an actionable, human-readable message. */
+function formatValidationError(first: { path: string; message: string } | undefined): string {
+	if (!first) return "invalid request body";
+	// Path looks like "/url" or "/args"; strip the leading slash for readability.
+	const field = first.path.replace(/^\//, "") || "(root)";
+	return `${first.message} at '${field}'`;
+}
+
+export function validateCloneRequest(raw: unknown): ValidationResult<CloneRequest> {
+	if (cloneValidator.Check(raw)) {
+		// `Check` is a type guard at the value level, so the cast is unnecessary —
+		// TypeScript narrows `raw` for us here.
+		return { ok: true, value: raw };
+	}
+	const [first] = [...cloneValidator.Errors(raw)];
+	return { ok: false, error: formatValidationError(first) };
+}
+
+export function validateToolRequest(raw: unknown): ValidationResult<ToolRequest> {
+	if (toolValidator.Check(raw)) {
+		return { ok: true, value: raw };
+	}
+	const [first] = [...toolValidator.Errors(raw)];
+	return { ok: false, error: formatValidationError(first) };
+}

--- a/src/sandbox/worker.ts
+++ b/src/sandbox/worker.ts
@@ -15,6 +15,7 @@ import { closeSync, openSync } from "node:fs";
 import { buildToolCommand } from "../tool-commands";
 import type { ErrorType } from "../types";
 import { isolatedGitCommand, isolatedGitToolCommand, isolatedToolCommand } from "./isolation";
+import { type CloneRequest, type ToolRequest, validateCloneRequest, validateToolRequest } from "./request-schemas";
 
 /** Path to seccomp BPF filter that blocks network sockets (arch-specific) */
 const SECCOMP_ARCH = process.arch === "arm64" ? "arm64" : "x64";
@@ -210,11 +211,6 @@ setInterval(() => {
 // Clone (async)
 // =============================================================================
 
-interface CloneRequest {
-	url: string;
-	commitish?: string;
-}
-
 /** Translate raw git clone stderr into a user-friendly error message. */
 function friendlyCloneError(stderr: string, url: string): string {
 	const s = stderr.toLowerCase();
@@ -323,10 +319,9 @@ async function executeClone(jobKey: string, url: string, commitish: string): Pro
  * If a clone is already in progress, returns "cloning" (dedup).
  */
 function handleClone(body: CloneRequest): Response {
+	// `body` is already schema-validated at the HTTP boundary — `url` is
+	// guaranteed to be a non-empty string, so no per-field nil checks here.
 	const { url, commitish = "HEAD" } = body;
-	if (!url) {
-		return Response.json({ ok: false, error: "url is required" }, { status: 400 });
-	}
 
 	const slug = slugify(url);
 	const jobKey = `${slug}:${commitish}`;
@@ -409,18 +404,11 @@ function handleCloneStatus(slug: string, commitish: string): Response {
 // Tool execution
 // =============================================================================
 
-interface ToolRequest {
-	slug: string;
-	sha: string;
-	name: string;
-	args: Record<string, unknown>;
-}
-
 async function handleTool(body: ToolRequest): Promise<Response> {
+	// `body` is already schema-validated at the HTTP boundary — required string
+	// fields are guaranteed present and non-empty. Per-tool arg validation still
+	// happens downstream in `buildToolCommand`.
 	const { slug, sha, name, args } = body;
-	if (!slug || !sha || !name) {
-		return Response.json({ ok: false, error: "slug, sha, and name are required" }, { status: 400 });
-	}
 
 	const shortSha = sha.slice(0, 12);
 	const worktree = `${repoDir(slug)}/trees/${shortSha}`;
@@ -485,6 +473,22 @@ function checkAuth(req: Request): Response | null {
 	return null;
 }
 
+/**
+ * Parse a request body as JSON, returning a discriminated result.
+ *
+ * `req.json()` throws `SyntaxError` on malformed JSON; letting that bubble up
+ * would produce an opaque 500. Catching it here keeps the failure mode at
+ * the boundary: bad JSON → 400 Bad Request with a clear message.
+ */
+async function parseJsonBody(req: Request): Promise<{ ok: true; value: unknown } | { ok: false; error: string }> {
+	try {
+		return { ok: true, value: await req.json() };
+	} catch (err) {
+		const msg = err instanceof Error ? err.message : String(err);
+		return { ok: false, error: `Malformed JSON body: ${msg}` };
+	}
+}
+
 /** Extract key params from request body for logging. */
 function requestSummary(pathname: string, body: unknown): string {
 	if (pathname === "/clone") {
@@ -518,17 +522,40 @@ const server = Bun.serve({
 		let response: Response;
 
 		if (pathname === "/clone" && req.method === "POST") {
-			body = await req.json();
-			console.info(`[sandbox] ${req.method} ${pathname} ${requestSummary(pathname, body)}`);
-			response = handleClone(body as CloneRequest);
+			const parsed = await parseJsonBody(req);
+			if (!parsed.ok) {
+				response = Response.json({ ok: false, error: parsed.error }, { status: 400 });
+			} else {
+				body = parsed.value;
+				console.info(`[sandbox] ${req.method} ${pathname} ${requestSummary(pathname, body)}`);
+				// Validate untrusted input at the boundary. A cast is not validation —
+				// malformed payloads must be rejected here so downstream helpers only
+				// ever see well-formed `CloneRequest` values.
+				const validated = validateCloneRequest(body);
+				if (!validated.ok) {
+					response = Response.json({ ok: false, error: `Invalid clone request: ${validated.error}` }, { status: 400 });
+				} else {
+					response = handleClone(validated.value);
+				}
+			}
 		} else if (pathname.startsWith("/clone/status/") && req.method === "GET") {
 			const slug = pathname.slice("/clone/status/".length);
 			const commitish = url.searchParams.get("commitish") || "HEAD";
 			response = handleCloneStatus(slug, commitish);
 		} else if (pathname === "/tool" && req.method === "POST") {
-			body = await req.json();
-			console.info(`[sandbox] ${req.method} ${pathname} ${requestSummary(pathname, body)}`);
-			response = await handleTool(body as ToolRequest);
+			const parsed = await parseJsonBody(req);
+			if (!parsed.ok) {
+				response = Response.json({ ok: false, error: parsed.error }, { status: 400 });
+			} else {
+				body = parsed.value;
+				console.info(`[sandbox] ${req.method} ${pathname} ${requestSummary(pathname, body)}`);
+				const validated = validateToolRequest(body);
+				if (!validated.ok) {
+					response = Response.json({ ok: false, error: `Invalid tool request: ${validated.error}` }, { status: 400 });
+				} else {
+					response = await handleTool(validated.value);
+				}
+			}
 		} else if (pathname === "/reset" && req.method === "POST") {
 			console.info(`[sandbox] ${req.method} ${pathname}`);
 			response = await handleReset();

--- a/test/sandbox/request-schemas.test.ts
+++ b/test/sandbox/request-schemas.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Unit tests for sandbox worker HTTP request body validators.
+ *
+ * These exercise the pure validation layer directly — they don't require
+ * the sandbox container to be running. Integration-level 400 responses
+ * are covered in sandbox.integration.test.ts.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { validateCloneRequest, validateToolRequest } from "../../src/sandbox/request-schemas";
+
+describe("validateCloneRequest", () => {
+	test("accepts minimal valid body (url only)", () => {
+		const result = validateCloneRequest({ url: "https://github.com/octocat/Hello-World" });
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.value.url).toBe("https://github.com/octocat/Hello-World");
+			expect(result.value.commitish).toBeUndefined();
+		}
+	});
+
+	test("accepts optional commitish", () => {
+		const result = validateCloneRequest({
+			url: "https://github.com/octocat/Hello-World",
+			commitish: "main",
+		});
+		expect(result.ok).toBe(true);
+	});
+
+	test("ignores extra fields (permissive additionalProperties)", () => {
+		const result = validateCloneRequest({
+			url: "https://github.com/octocat/Hello-World",
+			weird_extra: 42,
+		});
+		expect(result.ok).toBe(true);
+	});
+
+	test("rejects missing url", () => {
+		const result = validateCloneRequest({});
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.error).toContain("url");
+	});
+
+	test("rejects non-string url", () => {
+		const result = validateCloneRequest({ url: 123 });
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.error).toContain("url");
+	});
+
+	test("rejects empty url (minLength: 1)", () => {
+		const result = validateCloneRequest({ url: "" });
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.error).toContain("url");
+	});
+
+	test("rejects empty commitish when provided", () => {
+		const result = validateCloneRequest({
+			url: "https://github.com/octocat/Hello-World",
+			commitish: "",
+		});
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.error).toContain("commitish");
+	});
+
+	test("rejects non-object payloads", () => {
+		expect(validateCloneRequest(null).ok).toBe(false);
+		expect(validateCloneRequest(undefined).ok).toBe(false);
+		expect(validateCloneRequest("string").ok).toBe(false);
+		expect(validateCloneRequest(42).ok).toBe(false);
+		expect(validateCloneRequest([]).ok).toBe(false);
+	});
+});
+
+describe("validateToolRequest", () => {
+	const valid = {
+		slug: "github.com/octocat/Hello-World",
+		sha: "7fd1a60b01f91b314f59955a4e4d4e80d8edf11d",
+		name: "ls",
+		args: {},
+	};
+
+	test("accepts a valid body", () => {
+		const result = validateToolRequest(valid);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.value.name).toBe("ls");
+			expect(result.value.args).toEqual({});
+		}
+	});
+
+	test("accepts non-empty args object", () => {
+		const result = validateToolRequest({ ...valid, name: "rg", args: { pattern: "Hello" } });
+		expect(result.ok).toBe(true);
+	});
+
+	test("rejects missing slug", () => {
+		const { slug: _slug, ...rest } = valid;
+		const result = validateToolRequest(rest);
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.error).toContain("slug");
+	});
+
+	test("rejects missing sha", () => {
+		const { sha: _sha, ...rest } = valid;
+		const result = validateToolRequest(rest);
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.error).toContain("sha");
+	});
+
+	test("rejects missing name", () => {
+		const { name: _name, ...rest } = valid;
+		const result = validateToolRequest(rest);
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.error).toContain("name");
+	});
+
+	test("rejects missing args", () => {
+		const { args: _args, ...rest } = valid;
+		const result = validateToolRequest(rest);
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.error).toContain("args");
+	});
+
+	test("rejects empty string fields", () => {
+		expect(validateToolRequest({ ...valid, slug: "" }).ok).toBe(false);
+		expect(validateToolRequest({ ...valid, sha: "" }).ok).toBe(false);
+		expect(validateToolRequest({ ...valid, name: "" }).ok).toBe(false);
+	});
+
+	test("rejects non-object args", () => {
+		expect(validateToolRequest({ ...valid, args: null }).ok).toBe(false);
+		expect(validateToolRequest({ ...valid, args: "string" }).ok).toBe(false);
+		expect(validateToolRequest({ ...valid, args: 42 }).ok).toBe(false);
+	});
+
+	test("rejects wrong-typed top-level fields", () => {
+		expect(validateToolRequest({ ...valid, slug: 123 }).ok).toBe(false);
+		expect(validateToolRequest({ ...valid, sha: true }).ok).toBe(false);
+		expect(validateToolRequest({ ...valid, name: [] }).ok).toBe(false);
+	});
+
+	test("error messages name the offending field", () => {
+		const result = validateToolRequest({ ...valid, name: 42 });
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			// Format: "<message> at '<field>'"
+			expect(result.error).toMatch(/at 'name'/);
+		}
+	});
+});

--- a/test/sandbox/sandbox.integration.test.ts
+++ b/test/sandbox/sandbox.integration.test.ts
@@ -246,6 +246,91 @@ describe("sandbox network isolation", () => {
 });
 
 // =============================================================================
+// HTTP-Boundary Validation (malformed request bodies → 400, not 500)
+// =============================================================================
+
+// These tests bypass SandboxClient and hit the worker directly with raw fetch
+// so they can send payloads the client would never construct. The goal is to
+// pin down the HTTP contract: malformed bodies must produce 400 Bad Request
+// with an actionable error, not an opaque 500 from a deep helper.
+
+describe("sandbox HTTP-boundary validation", () => {
+	async function postJson(
+		path: string,
+		body: unknown,
+		rawBody?: string,
+	): Promise<{ status: number; body: { ok: boolean; error?: string } }> {
+		const res = await fetch(`${SANDBOX_URL}${path}`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: rawBody ?? JSON.stringify(body),
+		});
+		const parsed = (await res.json()) as { ok: boolean; error?: string };
+		return { status: res.status, body: parsed };
+	}
+
+	test("POST /clone with malformed JSON returns 400", async () => {
+		if (!(await isSandboxRunning())) return;
+
+		const { status, body } = await postJson("/clone", null, "{not json");
+		expect(status).toBe(400);
+		expect(body.ok).toBe(false);
+		expect(body.error).toMatch(/JSON/i);
+	});
+
+	test("POST /clone with missing url returns 400", async () => {
+		if (!(await isSandboxRunning())) return;
+
+		const { status, body } = await postJson("/clone", {});
+		expect(status).toBe(400);
+		expect(body.ok).toBe(false);
+		expect(body.error).toContain("url");
+	});
+
+	test("POST /clone with wrong-typed url returns 400", async () => {
+		if (!(await isSandboxRunning())) return;
+
+		const { status, body } = await postJson("/clone", { url: 123 });
+		expect(status).toBe(400);
+		expect(body.ok).toBe(false);
+		expect(body.error).toContain("url");
+	});
+
+	test("POST /tool with missing required fields returns 400", async () => {
+		if (!(await isSandboxRunning())) return;
+
+		const { status, body } = await postJson("/tool", { slug: "x" });
+		expect(status).toBe(400);
+		expect(body.ok).toBe(false);
+		// Error should point at one of the missing fields (sha / name / args).
+		expect(body.error).toMatch(/sha|name|args/);
+	});
+
+	test("POST /tool with non-object args returns 400", async () => {
+		if (!(await isSandboxRunning())) return;
+
+		const { status, body } = await postJson("/tool", {
+			slug: "github.com/octocat/Hello-World",
+			sha: "7fd1a60b01f91b314f59955a4e4d4e80d8edf11d",
+			name: "ls",
+			args: "not-an-object",
+		});
+		expect(status).toBe(400);
+		expect(body.ok).toBe(false);
+		expect(body.error).toContain("args");
+	});
+
+	test("POST /tool with malformed JSON returns 400", async () => {
+		if (!(await isSandboxRunning())) return;
+
+		const { status, body } = await postJson("/tool", null, "{not json");
+		expect(status).toBe(400);
+		expect(body.ok).toBe(false);
+		expect(body.error).toMatch(/JSON/i);
+	});
+});
+
+// =============================================================================
 // Input Validation
 // =============================================================================
 


### PR DESCRIPTION
Closes #123.

## Problem

`src/sandbox/worker.ts` cast raw `req.json()` payloads directly to `CloneRequest` / `ToolRequest`. Malformed input was not rejected at the HTTP boundary; instead it crashed deep inside `slugify` / `buildToolCommand` and surfaced as opaque 500s.

Verified against the running sandbox before the fix: `POST /clone {"url": 123}` crashes with `url.replace is not a function` inside `slugify`.

## Change

- **New module** `src/sandbox/request-schemas.ts`: TypeBox `CloneRequestSchema` / `ToolRequestSchema` with compiled validators exposed as `validateCloneRequest` / `validateToolRequest` returning a `{ ok; value } | { ok; error }` result. Kept separate from `worker.ts` so tests can import it without triggering the top-level `Bun.serve` call.
- **`src/sandbox/worker.ts`**:
  - Removed the two `body as CloneRequest` / `body as ToolRequest` casts.
  - Added `parseJsonBody` helper that catches `SyntaxError` from `req.json()` and returns 400 for malformed JSON (previously a 500).
  - Dispatch validates before calling handlers; schema failures → 400 with `Invalid <clone|tool> request: <message> at '<field>'`.
  - Dropped the now-dead in-handler `if (!url)` / `if (!slug || !sha || !name)` checks — handlers operate only on trusted, validated values.
- **`src/sandbox/Containerfile`**: added `COPY sandbox/request-schemas.ts` so the worker image ships the new module.

## Tests

- **`test/sandbox/request-schemas.test.ts`** (new, 18 tests): exhaustive unit coverage for the validators — missing / empty / wrong-typed fields, non-object payloads, extra-field permissiveness, error-message field paths.
- **`test/sandbox/sandbox.integration.test.ts`**: new `sandbox HTTP-boundary validation` block uses raw `fetch` (payloads the client would never construct) to confirm 400 for malformed JSON, missing fields, wrong types, and non-object `args` on both endpoints.

## Verification

- `bunx tsc --noEmit`: clean
- `bun run check` (Biome): clean
- `bun test`: 373 pre-existing tests pass; all 18 new unit tests pass. The 4 new integration tests need the sandbox container rebuilt to pick up the new worker code — run `sudo just sandbox-down && sudo just sandbox-up` before `bun test test/sandbox/sandbox.integration.test.ts`.

## Acceptance criteria

- [x] Raw `req.json()` payloads are not cast to `CloneRequest` / `ToolRequest`
- [x] Clone and tool bodies are schema-validated before use
- [x] Invalid payloads return 400, not 500
- [x] Validation errors are actionable (message + field path)
- [x] Tests cover malformed payloads for both endpoints