### PR TITLE
refactor(turn-result-builder): remove unused imperative methods

### DIFF
--- a/src/turn-result-builder.ts
+++ b/src/turn-result-builder.ts
@@ -151,35 +151,6 @@ export class TurnResultBuilder {
 		}
 	}
 
-	/** Add an iteration_start step (called by the session layer). */
-	addIterationStart(index: number): void {
-		this.#steps.push({ type: "iteration_start", index });
-	}
-
-	/** Set the turn error (called by the session layer). */
-	setError(errorType: ErrorType, message: string, retryability: Retryability, details?: unknown): void {
-		this.#error = { errorType, message, retryability, details };
-		this.#steps.push({
-			type: "error",
-			errorType,
-			source: errorSource(errorType),
-			message,
-			retryability,
-			details,
-		});
-	}
-
-	/** Accumulate token usage (called by the session layer after each iteration). */
-	addUsage(usage: Partial<TokenUsage>): void {
-		this.#usage = {
-			inputTokens: this.#usage.inputTokens + (usage.inputTokens ?? 0),
-			outputTokens: this.#usage.outputTokens + (usage.outputTokens ?? 0),
-			totalTokens: this.#usage.totalTokens + (usage.totalTokens ?? 0),
-			cacheReadTokens: this.#usage.cacheReadTokens + (usage.cacheReadTokens ?? 0),
-			cacheWriteTokens: this.#usage.cacheWriteTokens + (usage.cacheWriteTokens ?? 0),
-		};
-	}
-
 	/** Build the final immutable TurnResult. */
 	build(): TurnResult {
 		const defaultMetadata: TurnMetadata = {

--- a/test/turn-result-builder.test.ts
+++ b/test/turn-result-builder.test.ts
@@ -206,13 +206,13 @@ describe("TurnResultBuilder", () => {
 	});
 
 	describe("iteration tracking", () => {
-		test("addIterationStart() adds an iteration_start step", () => {
-			const builder = new TurnResultBuilder();
-			builder.addIterationStart(0);
-			builder.process({ type: "text", text: "response" });
-			builder.addIterationStart(1);
+		test("iteration_start event adds an iteration_start step", () => {
+			const result = buildFromEvents([
+				{ type: "iteration_start", index: 0 },
+				{ type: "text", text: "response" },
+				{ type: "iteration_start", index: 1 },
+			]);
 
-			const result = builder.build();
 			const iterSteps = result.steps.filter((s) => s.type === "iteration_start");
 			expect(iterSteps).toHaveLength(2);
 			expect(iterSteps[0]).toEqual({ type: "iteration_start", index: 0 });
@@ -275,16 +275,14 @@ describe("TurnResultBuilder", () => {
 			});
 		});
 
-		test("setError() sets turn-level error", () => {
-			const builder = new TurnResultBuilder();
-			builder.setError("max_iterations", "Max iterations reached", "no");
+		test("library-source error event classifies source correctly", () => {
+			const result = buildFromEvents([
+				{ type: "error", errorType: "max_iterations", message: "Max iterations reached", retryability: "no" },
+			]);
 
-			const result = builder.build();
-			expect(result.error).toEqual({
-				errorType: "max_iterations",
-				message: "Max iterations reached",
-				retryability: "no",
-			});
+			expect(result.error?.errorType).toBe("max_iterations");
+			expect(result.error?.message).toBe("Max iterations reached");
+			expect(result.error?.retryability).toBe("no");
 
 			const errorSteps = result.steps.filter((s) => s.type === "error");
 			expect(errorSteps).toHaveLength(1);
@@ -308,12 +306,23 @@ describe("TurnResultBuilder", () => {
 	});
 
 	describe("usage accumulation", () => {
-		test("addUsage() accumulates token counts", () => {
-			const builder = new TurnResultBuilder();
-			builder.addUsage({ inputTokens: 100, outputTokens: 50, totalTokens: 150 });
-			builder.addUsage({ inputTokens: 200, outputTokens: 30, totalTokens: 230, cacheReadTokens: 10 });
+		test("turn_end event records the accumulated token usage", () => {
+			const result = buildFromEvents([
+				{ type: "turn_start", turnId: "t-1", prompt: "Q", timestamp: 1000 },
+				{
+					type: "turn_end",
+					turnId: "t-1",
+					metadata: makeMetadata(),
+					usage: {
+						inputTokens: 300,
+						outputTokens: 80,
+						totalTokens: 380,
+						cacheReadTokens: 10,
+						cacheWriteTokens: 0,
+					},
+				},
+			]);
 
-			const result = builder.build();
 			expect(result.usage.inputTokens).toBe(300);
 			expect(result.usage.outputTokens).toBe(80);
 			expect(result.usage.totalTokens).toBe(380);


### PR DESCRIPTION
## Summary

- Removes dead methods `addIterationStart`, `setError`, and `addUsage` from `TurnResultBuilder`
- Rewrites the three corresponding unit tests against the supported event-driven API (`process(iteration_start | error | turn_end)`)
- Closes #125

## Context

Per the issue, these imperative helpers appeared dead — the session layer feeds the builder through `process(StreamEvent)` only.

Verified via `grep` across `src/`, `test/`, `scripts/`, and `web/`: the three methods are only referenced inside `test/turn-result-builder.test.ts`. `knip` also ran clean (it doesn't flag class members, but confirmed no related unused exports).

Kept the imports for `ErrorType` / `Retryability` because `#error` still uses them.

## Test plan

- [x] `bun test test/turn-result-builder.test.ts` — 20/20 pass
- [x] `bunx tsc --noEmit` — clean
- [x] Full CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)