### PR TITLE
test: replace Bun.sleep ordering with deterministic coordination

### DIFF
--- a/test/ask-stream.test.ts
+++ b/test/ask-stream.test.ts
@@ -160,12 +160,12 @@ describe("AskStream", () => {
 			},
 		];
 
-		// Use a slow producer so iteration is still in progress when .result() is called
+		// No explicit sync: async generator bodies execute synchronously up to the
+		// first yield, so by the time the iterator IIFE is created, the iterator
+		// has already set #consuming=true. .result() is guaranteed to observe
+		// mid-iteration and take the wait-for-done path.
 		const stream = new AskStreamImpl(async function* () {
-			for (const event of events) {
-				await Bun.sleep(10);
-				yield event;
-			}
+			yield* events;
 		});
 
 		const collected: StreamEvent[] = [];
@@ -174,15 +174,11 @@ describe("AskStream", () => {
 				collected.push(event);
 			}
 		})();
-
-		// Call .result() while iteration is still in progress
 		const resultPromise = stream.result();
 
 		const [, result] = await Promise.all([iterPromise, resultPromise]);
 
-		// Iterator should have seen all events
 		expect(collected).toEqual(events);
-		// .result() should have the same data, built from the same builder
 		expect(result.id).toBe("t-1");
 		expect(result.steps[0]).toEqual({ type: "text", text: "A", role: "assistant" });
 	});

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -294,22 +294,22 @@ describe("Session", () => {
 		});
 
 		test("concurrent ask() calls are serialized", async () => {
-			const order: string[] = [];
-			let streamCalls = 0;
-
+			// If two asks ran in parallel the natural await points in doAsk
+			// (compaction, iteration_start, ...) would let the second reach the
+			// stream fn before the first released.
+			let concurrency = 0;
+			let maxConcurrency = 0;
 			const customStream = (() => {
-				streamCalls++;
-				const n = streamCalls;
+				concurrency++;
+				maxConcurrency = Math.max(maxConcurrency, concurrency);
 				return {
 					[Symbol.asyncIterator]: async function* () {
-						order.push(`start-${n}`);
-						await Bun.sleep(30);
-						order.push(`end-${n}`);
-						yield { type: "text_delta", delta: `r${n}` };
+						yield { type: "text_delta", delta: "x" };
+						concurrency--;
 					},
 					result: async () => ({
 						role: "assistant" as const,
-						content: [{ type: "text" as const, text: `r${n}` }],
+						content: [{ type: "text" as const, text: "x" }],
 						usage: { input: 10, output: 5, totalTokens: 15 },
 						timestamp: Date.now(),
 						api: "test",
@@ -321,12 +321,9 @@ describe("Session", () => {
 			}) as unknown as SessionConfig["stream"];
 
 			const session = new Session(createMockRepo(), createMockConfig({ stream: customStream }));
+			await Promise.all([session.ask("q1").result(), session.ask("q2").result()]);
 
-			const s1 = session.ask("q1");
-			const s2 = session.ask("q2");
-			await Promise.all([s1.result(), s2.result()]);
-
-			expect(order).toEqual(["start-1", "end-1", "start-2", "end-2"]);
+			expect(maxConcurrency).toBe(1);
 		});
 	});
 


### PR DESCRIPTION
Closes #131.

Replaces `Bun.sleep(...)` used for sequencing async events with deterministic coordination in the two affected tests.

## `test/ask-stream.test.ts`

The `Bun.sleep(10)` here was protecting nothing. Async generator bodies run synchronously up to the first `yield`/`await`, so by the time the iterator IIFE is created on one line, `#consuming = true` has already been set, and `stream.result()` on the next line deterministically observes in-progress consumption and takes the wait-for-done path.

Removed the sleep, no replacement. Verified:

- 900/900 passes under `--rerun-each=100` on the file.
- Inverting the ordering (calling `.result()` before creating the iterator IIFE) deterministically fails with `"AskStream is already being consumed"`, confirming the test still exercises the property it claims to.

## `test/session.test.ts`

Here the sleep was load-bearing — without it, both async iterator bodies would run synchronously to completion before any suspension point, so broken serialization couldn't be observed via push ordering. The original test *needed* a forced suspension.

Rewrote the test to use an invariant rather than choreography: track peak concurrent stream-fn invocations. Under correct serialization the second ask is blocked on `prevPending` until the first completes, so peak is 1. Under broken serialization, `doAsk`'s natural `await` points (compaction, `yield turn_start`, etc.) let the second ask reach the stream fn while the first is still running, so peak is 2.

Verified:

- Correct code: 2250/2250 passes under `--rerun-each=50` on the full file.
- Simulated regression (commented out `await prevPending` in `session.ts`): deterministic failure with `peak = 2`.
- Restored: passes again.

Net across both files: +18 / −24.

## Notes

I first tried a `Promise.withResolvers` deferred-pair approach for the session test (hold the first ask open, assert the second hasn't started, release). It worked but was ~30 lines of setup to prove a one-line invariant. The counter approach exploits the same natural await points the production code relies on and needs no apparatus.
