### PR TITLE
refactor(tests): assert errorType instead of exact error messages

### DIFF
--- a/test/forge.test.ts
+++ b/test/forge.test.ts
@@ -3,11 +3,19 @@ import { existsSync } from "node:fs";
 import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import { MegasthenesError } from "../src/errors";
 import { cleanupRepo, connectRepo, type Forge, type Repo } from "../src/forge";
+import type { ErrorType } from "../src/types";
 
 // =============================================================================
 // Test Helpers
 // =============================================================================
+
+async function expectConnectError(promise: Promise<unknown>, errorType: ErrorType): Promise<void> {
+	const err = await promise.catch((e: unknown) => e);
+	expect(err).toBeInstanceOf(MegasthenesError);
+	expect((err as MegasthenesError).errorType).toBe(errorType);
+}
 
 interface TestRepo {
 	/** file:// URL to the bare repo */
@@ -232,29 +240,27 @@ describe("forge", () => {
 			expect(results[0].localPath).not.toBe(results[1].localPath);
 		});
 
-		test("throws for non-existent commitish", async () => {
-			expect(
-				connectRepo(repoUrl, {
-					forge: "github",
-					commitish: "nonexistent-branch",
-				}),
-			).rejects.toThrow("Failed to resolve commitish");
+		test("throws invalid_commitish for non-existent commitish", async () => {
+			await expectConnectError(
+				connectRepo(repoUrl, { forge: "github", commitish: "nonexistent-branch" }),
+				"invalid_commitish",
+			);
 		});
 
 		test("throws for invalid URL", async () => {
 			expect(connectRepo("not-a-url")).rejects.toThrow();
 		});
 
-		test("throws for unknown forge without explicit option", async () => {
-			expect(connectRepo("https://bitbucket.org/user/repo")).rejects.toThrow("Cannot infer forge from URL");
+		test("throws invalid_config for unknown forge without explicit option", async () => {
+			await expectConnectError(connectRepo("https://bitbucket.org/user/repo"), "invalid_config");
 		});
 
-		test("throws for URL with no path segments", async () => {
-			expect(connectRepo("https://github.com/", { forge: "github" })).rejects.toThrow("Invalid repo URL");
+		test("throws invalid_config for URL with no path segments", async () => {
+			await expectConnectError(connectRepo("https://github.com/", { forge: "github" }), "invalid_config");
 		});
 
-		test("throws for URL with only one path segment", async () => {
-			expect(connectRepo("https://github.com/user", { forge: "github" })).rejects.toThrow("Invalid repo URL");
+		test("throws invalid_config for URL with only one path segment", async () => {
+			await expectConnectError(connectRepo("https://github.com/user", { forge: "github" }), "invalid_config");
 		});
 
 		test("succeeds with explicit forge option for non-standard host", async () => {
@@ -400,10 +406,11 @@ describe("forge", () => {
 	describe("inferForge (indirect)", () => {
 		test("github.com URL infers github forge (error is not about forge inference)", async () => {
 			// connectRepo will fail (repo doesn't exist), but the error must NOT be
-			// about forge inference — proving inferForge("github.com") returned "github"
+			// about forge inference — proving inferForge("github.com") returned "github".
+			// With a well-formed URL, invalid_config is only produced by the forge-inference branch.
 			const err = await connectRepo("https://github.com/testuser/testrepo").catch((e: unknown) => e);
-			expect(err).toBeInstanceOf(Error);
-			expect((err as Error).message).not.toContain("Cannot infer forge");
+			expect(err).toBeInstanceOf(MegasthenesError);
+			expect((err as MegasthenesError).errorType).not.toBe("invalid_config");
 		});
 
 		test("gitlab.com URL infers gitlab forge (public repo connects without explicit forge option)", async () => {
@@ -412,8 +419,8 @@ describe("forge", () => {
 			expect(repo.url).toContain("gitlab.com");
 		}, 30_000);
 
-		test("custom domain without forge option throws 'Cannot infer forge'", async () => {
-			await expect(connectRepo("https://git.example.com/user/repo")).rejects.toThrow("Cannot infer forge");
+		test("custom domain without forge option throws invalid_config", async () => {
+			await expectConnectError(connectRepo("https://git.example.com/user/repo"), "invalid_config");
 		});
 	});
 

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -220,7 +220,7 @@ describe("Session", () => {
 			const result = await session.ask("Test").result();
 
 			expect(result.error).not.toBeNull();
-			expect(result.error?.message).toContain("API");
+			expect(result.error?.errorType).toBe("provider_error");
 		});
 
 		test("max iterations error produces TurnResult with .error set", async () => {
@@ -233,7 +233,7 @@ describe("Session", () => {
 			const result = await session.ask("Do something").result();
 
 			expect(result.error).not.toBeNull();
-			expect(result.error?.message).toContain("Max iterations reached");
+			expect(result.error?.errorType).toBe("max_iterations");
 		});
 
 		test("uses injected stream function", async () => {
@@ -446,7 +446,7 @@ describe("Session", () => {
 			const result = await session.ask("Test", { signal: controller.signal }).result();
 
 			expect(result.error).not.toBeNull();
-			expect(result.error?.message).toBe("Aborted");
+			expect(result.error?.errorType).toBe("aborted");
 		});
 
 		test("signal abort cancels the turn between iterations", async () => {

--- a/test/tracing.test.ts
+++ b/test/tracing.test.ts
@@ -339,31 +339,27 @@ function expectSpanErrorDetails(
 	span: RecordedSpan | undefined,
 	{
 		errorType,
-		message,
 		stage,
 		name = "Error",
-		exceptionMessage = message,
 		exceptionCount = 1,
 	}: {
 		errorType: string;
-		message: string;
 		stage?: string;
 		name?: string;
-		exceptionMessage?: string;
 		exceptionCount?: number;
 	},
 ) {
 	expect(span?.status.code).toBe(SpanStatusCode.ERROR);
-	expect(span?.status.message).toBe(message);
+	expect(typeof span?.status.message).toBe("string");
 	expect(span?.attributes["error.type"]).toBe(errorType);
 	if (stage !== undefined) {
 		expect(span?.attributes["megasthenes.error.stage"]).toBe(stage);
 	}
 	expect(span?.attributes["megasthenes.error.name"]).toBe(name);
-	expect(span?.attributes["megasthenes.error.message"]).toBe(message);
+	expect(typeof span?.attributes["megasthenes.error.message"]).toBe("string");
 	expect(span?.exceptions.length).toBe(exceptionCount);
 	if (exceptionCount > 0) {
-		expect(span?.exceptions[0]?.message).toBe(exceptionMessage);
+		expect(typeof span?.exceptions[0]?.message).toBe("string");
 	}
 }
 
@@ -568,7 +564,6 @@ describe("OTel tracing", () => {
 			const genSpan = recorder.getSpan("gen_ai.chat");
 			expectSpanErrorDetails(genSpan, {
 				errorType: "provider_error",
-				message: "API call failed: Rate limit exceeded",
 				stage: "generation",
 			});
 		});
@@ -735,7 +730,6 @@ describe("OTel tracing", () => {
 			const askSpan = recorder.getSpan("ask");
 			expectSpanErrorDetails(askSpan, {
 				errorType: "aborted",
-				message: "Aborted",
 				stage: "ask",
 			});
 		});
@@ -755,7 +749,6 @@ describe("OTel tracing", () => {
 			const askSpan = recorder.getSpan("ask");
 			expectSpanErrorDetails(askSpan, {
 				errorType: "max_iterations",
-				message: "Max iterations reached without a final answer.",
 				stage: "ask",
 			});
 		});
@@ -771,14 +764,12 @@ describe("OTel tracing", () => {
 
 			expectSpanErrorDetails(genSpan, {
 				errorType: "provider_error",
-				message: "API call failed: Rate limit exceeded",
 				stage: "generation",
 			});
 			expect(genSpan?.ended).toBe(true);
 
 			expectSpanErrorDetails(askSpan, {
 				errorType: "provider_error",
-				message: "API call failed: Rate limit exceeded",
 				stage: "ask",
 			});
 			expect(askSpan?.ended).toBe(true);
@@ -797,12 +788,10 @@ describe("OTel tracing", () => {
 			const genSpan = recorder.getSpan("gen_ai.chat");
 			expectSpanErrorDetails(genSpan, {
 				errorType: "context_overflow",
-				message: "API call failed: prompt is too long: 250000 tokens > 200000 maximum",
 				stage: "generation",
 			});
 			expectSpanErrorDetails(askSpan, {
 				errorType: "context_overflow",
-				message: "API call failed: prompt is too long: 250000 tokens > 200000 maximum",
 				stage: "ask",
 			});
 		});
@@ -818,12 +807,10 @@ describe("OTel tracing", () => {
 			const genSpan = recorder.getSpan("gen_ai.chat");
 			expectSpanErrorDetails(genSpan, {
 				errorType: "network_error",
-				message: "API call failed: fetch failed",
 				stage: "generation",
 			});
 			expectSpanErrorDetails(askSpan, {
 				errorType: "network_error",
-				message: "API call failed: fetch failed",
 				stage: "ask",
 			});
 		});
@@ -850,7 +837,6 @@ describe("OTel tracing", () => {
 			const toolSpan = recorder.getSpans("gen_ai.execute_tool")[0];
 			expectSpanErrorDetails(toolSpan, {
 				errorType: "internal_error",
-				message: "tool crashed",
 				stage: "tool_execution",
 			});
 			expect(toolSpan?.ended).toBe(true);
@@ -886,7 +872,6 @@ describe("OTel tracing", () => {
 			const genSpan = recorder.getSpan("gen_ai.chat");
 			expectSpanErrorDetails(genSpan, {
 				errorType: "empty_response",
-				message: "Model returned an empty response",
 				stage: "generation",
 			});
 			expect(genSpan?.ended).toBe(true);
@@ -915,7 +900,6 @@ describe("OTel tracing", () => {
 			const genSpan = recorder.getSpan("gen_ai.chat");
 			expectSpanErrorDetails(genSpan, {
 				errorType: "empty_response",
-				message: "Model returned an empty response",
 				stage: "generation",
 			});
 		});
@@ -948,7 +932,6 @@ describe("OTel tracing", () => {
 			const askSpan = recorder.getSpan("ask");
 			expectSpanErrorDetails(askSpan, {
 				errorType: "provider_error",
-				message: "API call failed: stream setup exploded",
 				stage: "ask",
 			});
 		});


### PR DESCRIPTION
## Summary

- Replace brittle exact/substring assertions on internal error prose with assertions on the stable `errorType` discriminator across `session`, `tracing`, and `forge` tests.
- `tracing`: drop the required `message` param from `expectSpanErrorDetails`; it now verifies the message-bearing fields are present strings rather than exact text.
- `forge`: introduce an `expectConnectError(promise, errorType)` helper and migrate `rejects.toThrow("…")` callers to it.

Closes #129.

## Test plan

- [x] `bun test test/session.test.ts test/tracing.test.ts` — 81/81 pass
- [x] `bun test test/forge.test.ts` — 30/30 pass
- [x] `bunx tsc --noEmit` — clean
- [x] CI green

Sandbox-suite failures seen locally predate this change (they require a running sandbox + bwrap) and are unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)