### PR TITLE
test(session): drop wiring-only tests; closes #126

### DIFF
--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -236,63 +236,6 @@ describe("Session", () => {
 			expect(result.error?.errorType).toBe("max_iterations");
 		});
 
-		test("uses injected stream function", async () => {
-			let streamCalled = false;
-			const customStream = (() => {
-				streamCalled = true;
-				return createMockStreamResult();
-			}) as unknown as SessionConfig["stream"];
-
-			const session = new Session(createMockRepo(), createMockConfig({ stream: customStream }));
-			await session.ask("Test").result();
-			expect(streamCalled).toBe(true);
-		});
-
-		test("adaptive thinking uses stream() with thinkingEnabled", async () => {
-			let capturedOptions: unknown;
-			let streamCalled = false;
-			let streamSimpleCalled = false;
-			const customStream = ((_model: unknown, _context: unknown, options?: unknown) => {
-				streamCalled = true;
-				capturedOptions = options;
-				return createMockStreamResult();
-			}) as unknown as SessionConfig["stream"];
-			const customStreamSimple = ((_model: unknown, _context: unknown, _options?: unknown) => {
-				streamSimpleCalled = true;
-				return createMockStreamResult();
-			}) as unknown as SessionConfig["streamSimple"];
-
-			const session = new Session(
-				createMockRepo(),
-				createMockConfig({ stream: customStream, streamSimple: customStreamSimple, thinking: { type: "adaptive" } }),
-			);
-
-			await session.ask("Test").result();
-			expect(streamCalled).toBe(true);
-			expect(streamSimpleCalled).toBe(false);
-			expect(capturedOptions).toEqual({ thinkingEnabled: true });
-		});
-
-		test("effort-based thinking uses streamSimple() with reasoning option", async () => {
-			let capturedOptions: unknown;
-			let streamSimpleCalled = false;
-			const customStream = (() => createMockStreamResult()) as unknown as SessionConfig["stream"];
-			const customStreamSimple = ((_model: unknown, _context: unknown, options?: unknown) => {
-				streamSimpleCalled = true;
-				capturedOptions = options;
-				return createMockStreamResult();
-			}) as unknown as SessionConfig["streamSimple"];
-
-			const session = new Session(
-				createMockRepo(),
-				createMockConfig({ stream: customStream, streamSimple: customStreamSimple, thinking: { effort: "high" } }),
-			);
-
-			await session.ask("Test").result();
-			expect(streamSimpleCalled).toBe(true);
-			expect(capturedOptions).toEqual({ reasoning: "high" });
-		});
-
 		test("concurrent ask() calls are serialized", async () => {
 			// If two asks ran in parallel the natural await points in doAsk
 			// (compaction, iteration_start, ...) would let the second reach the


### PR DESCRIPTION
## Summary
- Removes three tests in `test/session.test.ts` that only asserted implementation wiring (that an injected `stream`/`streamSimple` was called, or that a specific internal options object was passed).
- The behavioral contracts those tests pretended to cover are already asserted on observable output (`result.metadata.config.thinkingConfig`) in the `TurnMetadata reflects per-turn overrides` block — see `test/session.test.ts:587-606`.
- Net effect: same behavioral coverage, fewer tests coupled to `Session` internals.

## Tests deleted
- `"uses injected stream function"` — only checked `streamCalled === true`; every other test in the suite that injects a stream and asserts on `result` already proves injection works.
- `"adaptive thinking uses stream() with thinkingEnabled"` — asserted the exact shape `{ thinkingEnabled: true }` on the internal call. Contract is covered by the existing assertion that `result.metadata.config.thinkingConfig === { type: "adaptive" }`.
- `"effort-based thinking uses streamSimple() with reasoning option"` — asserted `{ reasoning: "high" }` on the internal call. Covered by the existing assertion that `result.metadata.config.thinkingConfig === { effort: "high" }`.

## Test plan
- [x] `bun test test/session.test.ts` — 48 pass, 0 fail
- [x] `bunx tsc --noEmit` clean
- [x] `bun run lint` clean (pre-existing biome schema-version info unrelated)

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)