### PR TITLE
refactor(forge): decouple providers and git helpers from orchestrator

### DIFF
--- a/src/forge.ts
+++ b/src/forge.ts
@@ -1,117 +1,20 @@
-import { access, mkdir, rm } from "node:fs/promises";
 import { homedir } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import { join, resolve } from "node:path";
 import type { Span } from "@opentelemetry/api";
 import { MegasthenesError } from "./errors";
+import {
+	type CachePhaseResult,
+	ensureCachedRepo,
+	ensureWorktree,
+	removeWorktree,
+	resolveCommitish,
+	withCloneLock,
+} from "./forge/git";
+import { type Forge, type ForgeName, forges, inferForge, parseRepoPath } from "./forge/providers";
 import { endChildSpan, withChildSpan } from "./tracing";
 
-/**
- * Lock map to prevent race conditions when cloning the same repo in parallel.
- *
- * When multiple concurrent calls try to clone the same repository, this lock ensures
- * only one clone happens while others wait. Without this, concurrent clones to the
- * same path would corrupt the repository.
- *
- * Note: This lock is process-local. If multiple Node.js processes run simultaneously,
- * they will not share this lock and may still race. For multi-process scenarios,
- * consider using file-based locking or ensuring only one process clones at a time.
- */
-const cloneLocks = new Map<string, Promise<void>>();
-
-async function withCloneLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
-	while (cloneLocks.has(key)) {
-		await cloneLocks.get(key);
-	}
-
-	let resolveLock: (() => void) | undefined;
-	const lockPromise = new Promise<void>((r) => {
-		resolveLock = r;
-	});
-	cloneLocks.set(key, lockPromise);
-
-	try {
-		return await fn();
-	} finally {
-		cloneLocks.delete(key);
-		resolveLock?.();
-	}
-}
-
-async function exists(path: string): Promise<boolean> {
-	try {
-		await access(path);
-		return true;
-	} catch {
-		return false;
-	}
-}
-
-async function commitishExistsLocally(repoPath: string, commitish: string): Promise<boolean> {
-	const proc = Bun.spawn(["git", "cat-file", "-t", commitish], {
-		cwd: repoPath,
-		stdout: "pipe",
-		stderr: "pipe",
-	});
-	const output = (await new Response(proc.stdout).text()).trim();
-	const exitCode = await proc.exited;
-	return exitCode === 0 && (output === "commit" || output === "tag");
-}
-
-/** Supported git forge types */
-export type ForgeName = "github" | "gitlab";
-
-/** Interface for git forge implementations */
-export interface Forge {
-	/** The forge identifier */
-	name: ForgeName;
-	/** Build an authenticated clone URL */
-	buildCloneUrl(repoUrl: string, token?: string): string;
-}
-
-const GitHubForge: Forge = {
-	name: "github",
-	buildCloneUrl(repoUrl: string, token?: string): string {
-		if (!token) return repoUrl;
-		const url = new URL(repoUrl);
-		url.username = token;
-		return url.toString();
-	},
-};
-
-const GitLabForge: Forge = {
-	name: "gitlab",
-	buildCloneUrl(repoUrl: string, token?: string): string {
-		if (!token) return repoUrl;
-		const url = new URL(repoUrl);
-		url.username = "oauth2";
-		url.password = token;
-		return url.toString();
-	},
-};
-
-const forges: Record<ForgeName, Forge> = {
-	github: GitHubForge,
-	gitlab: GitLabForge,
-};
-
-export function inferForge(repoUrl: string): ForgeName | null {
-	const url = new URL(repoUrl);
-	if (url.hostname === "github.com") return "github";
-	if (url.hostname === "gitlab.com") return "gitlab";
-	return null;
-}
-
-function parseRepoPath(repoUrl: string): { username: string; reponame: string } {
-	const url = new URL(repoUrl);
-	const parts = url.pathname
-		.replace(/^\//, "")
-		.replace(/\.git$/, "")
-		.split("/");
-	if (parts.length < 2 || !parts[0] || !parts[1]) {
-		throw new MegasthenesError("invalid_config", `Invalid repo URL: ${repoUrl}`, { retryability: "no" });
-	}
-	return { username: parts[0], reponame: parts[1] };
-}
+export type { Forge, ForgeName } from "./forge/providers";
+export { inferForge } from "./forge/providers";
 
 /** Options for connecting to a repository */
 export interface ConnectOptions {
@@ -137,12 +40,6 @@ export interface Repo {
 	cachePath: string;
 }
 
-// Stderr substrings that indicate there was nothing to remove: git already
-// doesn't track the worktree, or the path is gone. Matching any of these
-// means the desired end-state is already achieved, so cleanup is treated as
-// successful (idempotent remove) rather than failed.
-const CLEANUP_ALREADY_DONE_MARKERS = ["is not a working tree", "No such file or directory"] as const;
-
 /**
  * Outcome of `cleanupRepo`. On failure, `details` is an opaque bag the caller
  * can forward to a logger without inspecting — keeping callers free of
@@ -162,109 +59,12 @@ export type CleanupResult = { ok: true } | { ok: false; details?: Record<string,
  */
 export async function cleanupRepo(repo: Repo): Promise<CleanupResult> {
 	try {
-		const proc = Bun.spawn(["git", "worktree", "remove", "--force", repo.localPath], {
-			cwd: repo.cachePath,
-			stdout: "pipe",
-			stderr: "pipe",
-		});
-		const [exitCode, stderr] = await Promise.all([proc.exited, new Response(proc.stderr).text()]);
-		if (exitCode === 0) return { ok: true };
-		if (CLEANUP_ALREADY_DONE_MARKERS.some((marker) => stderr.includes(marker))) {
-			return { ok: true };
-		}
-		return { ok: false, details: { path: repo.localPath, exitCode, stderr: stderr.trim() } };
+		const result = await removeWorktree(repo.cachePath, repo.localPath);
+		if (result.ok) return { ok: true };
+		return { ok: false, details: { path: repo.localPath, exitCode: result.exitCode, stderr: result.stderr } };
 	} catch (error) {
 		return { ok: false, details: { path: repo.localPath, error } };
 	}
-}
-
-type CacheOperation = "fetch" | "reuse_cache" | "clone";
-
-interface CachePhaseResult {
-	operation: CacheOperation;
-	cacheExisted: boolean;
-}
-
-async function ensureCachedRepo(
-	cachePath: string,
-	commitish: string,
-	buildCloneUrl: () => string,
-): Promise<CachePhaseResult> {
-	const headFile = join(cachePath, "HEAD");
-	const cacheExists = await exists(headFile);
-
-	if (cacheExists) {
-		const hasCommitish = await commitishExistsLocally(cachePath, commitish);
-		if (hasCommitish) {
-			return { operation: "reuse_cache", cacheExisted: true };
-		}
-		const proc = Bun.spawn(["git", "fetch", "origin", "--tags"], {
-			cwd: cachePath,
-			stdout: "inherit",
-			stderr: "inherit",
-		});
-		const fetchExit = await proc.exited;
-		if (fetchExit !== 0) {
-			throw new MegasthenesError("fetch_failed", `git fetch failed with exit code ${fetchExit}`, {
-				retryability: "yes",
-			});
-		}
-		return { operation: "fetch", cacheExisted: true };
-	}
-
-	// Clean up incomplete clone if directory exists but HEAD doesn't
-	if (await exists(cachePath)) {
-		await rm(cachePath, { recursive: true, force: true });
-	}
-	await mkdir(cachePath, { recursive: true });
-	const proc = Bun.spawn(["git", "clone", "--bare", "--filter=blob:none", buildCloneUrl(), cachePath], {
-		stdout: "inherit",
-		stderr: "inherit",
-	});
-	const exitCode = await proc.exited;
-	if (exitCode !== 0) {
-		throw new MegasthenesError("clone_failed", `git clone failed with exit code ${exitCode}`, {
-			retryability: "yes",
-		});
-	}
-	return { operation: "clone", cacheExisted: false };
-}
-
-async function resolveCommitish(cachePath: string, commitish: string): Promise<string> {
-	const proc = Bun.spawn(["git", "rev-parse", commitish], {
-		cwd: cachePath,
-		stdout: "pipe",
-		stderr: "pipe",
-	});
-	const resolved = (await new Response(proc.stdout).text()).trim();
-	const exitCode = await proc.exited;
-	if (exitCode !== 0) {
-		throw new MegasthenesError("invalid_commitish", `Failed to resolve commitish: ${commitish}`, {
-			retryability: "no",
-		});
-	}
-	return resolved;
-}
-
-async function ensureWorktree(cachePath: string, sha: string, worktreePath: string): Promise<{ reused: boolean }> {
-	if (await exists(worktreePath)) {
-		return { reused: true };
-	}
-	await mkdir(dirname(worktreePath), { recursive: true });
-	const proc = Bun.spawn(["git", "worktree", "add", worktreePath, sha], {
-		cwd: cachePath,
-		stdout: "pipe",
-		stderr: "pipe",
-	});
-	const exitCode = await proc.exited;
-	// If `git worktree add` failed, it may be because a concurrent call won the race.
-	// Re-check the path: if still missing, it's a real failure.
-	if (exitCode !== 0 && !(await exists(worktreePath))) {
-		throw new MegasthenesError("clone_failed", `git worktree add failed with exit code ${exitCode}`, {
-			retryability: "yes",
-		});
-	}
-	return { reused: exitCode !== 0 };
 }
 
 function recordCachePhaseOutcome(span: Span | undefined, cachePath: string, result: CachePhaseResult): void {

--- a/src/forge/git.ts
+++ b/src/forge/git.ts
@@ -15,6 +15,12 @@ import { MegasthenesError } from "../errors";
  */
 const cloneLocks = new Map<string, Promise<void>>();
 
+// Stderr substrings that indicate there was nothing to remove: git already
+// doesn't track the worktree, or the path is gone. Matching any of these
+// means the desired end-state is already achieved, so removal is treated as
+// successful (idempotent remove) rather than failed.
+const CLEANUP_ALREADY_DONE_MARKERS = ["is not a working tree", "No such file or directory"] as const;
+
 export async function withCloneLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
 	while (cloneLocks.has(key)) {
 		await cloneLocks.get(key);
@@ -146,12 +152,6 @@ export async function ensureWorktree(
 	}
 	return { reused: exitCode !== 0 };
 }
-
-// Stderr substrings that indicate there was nothing to remove: git already
-// doesn't track the worktree, or the path is gone. Matching any of these
-// means the desired end-state is already achieved, so removal is treated as
-// successful (idempotent remove) rather than failed.
-const CLEANUP_ALREADY_DONE_MARKERS = ["is not a working tree", "No such file or directory"] as const;
 
 export type RemoveWorktreeResult = { ok: true } | { ok: false; exitCode: number; stderr: string };
 

--- a/src/forge/git.ts
+++ b/src/forge/git.ts
@@ -1,0 +1,178 @@
+import { access, mkdir, rm } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { MegasthenesError } from "../errors";
+
+/**
+ * Lock map to prevent race conditions when cloning the same repo in parallel.
+ *
+ * When multiple concurrent calls try to clone the same repository, this lock ensures
+ * only one clone happens while others wait. Without this, concurrent clones to the
+ * same path would corrupt the repository.
+ *
+ * Note: This lock is process-local. If multiple Node.js processes run simultaneously,
+ * they will not share this lock and may still race. For multi-process scenarios,
+ * consider using file-based locking or ensuring only one process clones at a time.
+ */
+const cloneLocks = new Map<string, Promise<void>>();
+
+export async function withCloneLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
+	while (cloneLocks.has(key)) {
+		await cloneLocks.get(key);
+	}
+
+	let resolveLock: (() => void) | undefined;
+	const lockPromise = new Promise<void>((r) => {
+		resolveLock = r;
+	});
+	cloneLocks.set(key, lockPromise);
+
+	try {
+		return await fn();
+	} finally {
+		cloneLocks.delete(key);
+		resolveLock?.();
+	}
+}
+
+export async function exists(path: string): Promise<boolean> {
+	try {
+		await access(path);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+export async function commitishExistsLocally(repoPath: string, commitish: string): Promise<boolean> {
+	const proc = Bun.spawn(["git", "cat-file", "-t", commitish], {
+		cwd: repoPath,
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const output = (await new Response(proc.stdout).text()).trim();
+	const exitCode = await proc.exited;
+	return exitCode === 0 && (output === "commit" || output === "tag");
+}
+
+export type CacheOperation = "fetch" | "reuse_cache" | "clone";
+
+export interface CachePhaseResult {
+	operation: CacheOperation;
+	cacheExisted: boolean;
+}
+
+export async function ensureCachedRepo(
+	cachePath: string,
+	commitish: string,
+	buildCloneUrl: () => string,
+): Promise<CachePhaseResult> {
+	const headFile = join(cachePath, "HEAD");
+	const cacheExists = await exists(headFile);
+
+	if (cacheExists) {
+		const hasCommitish = await commitishExistsLocally(cachePath, commitish);
+		if (hasCommitish) {
+			return { operation: "reuse_cache", cacheExisted: true };
+		}
+		const proc = Bun.spawn(["git", "fetch", "origin", "--tags"], {
+			cwd: cachePath,
+			stdout: "inherit",
+			stderr: "inherit",
+		});
+		const fetchExit = await proc.exited;
+		if (fetchExit !== 0) {
+			throw new MegasthenesError("fetch_failed", `git fetch failed with exit code ${fetchExit}`, {
+				retryability: "yes",
+			});
+		}
+		return { operation: "fetch", cacheExisted: true };
+	}
+
+	// Clean up incomplete clone if directory exists but HEAD doesn't
+	if (await exists(cachePath)) {
+		await rm(cachePath, { recursive: true, force: true });
+	}
+	await mkdir(cachePath, { recursive: true });
+	const proc = Bun.spawn(["git", "clone", "--bare", "--filter=blob:none", buildCloneUrl(), cachePath], {
+		stdout: "inherit",
+		stderr: "inherit",
+	});
+	const exitCode = await proc.exited;
+	if (exitCode !== 0) {
+		throw new MegasthenesError("clone_failed", `git clone failed with exit code ${exitCode}`, {
+			retryability: "yes",
+		});
+	}
+	return { operation: "clone", cacheExisted: false };
+}
+
+export async function resolveCommitish(cachePath: string, commitish: string): Promise<string> {
+	const proc = Bun.spawn(["git", "rev-parse", commitish], {
+		cwd: cachePath,
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const resolved = (await new Response(proc.stdout).text()).trim();
+	const exitCode = await proc.exited;
+	if (exitCode !== 0) {
+		throw new MegasthenesError("invalid_commitish", `Failed to resolve commitish: ${commitish}`, {
+			retryability: "no",
+		});
+	}
+	return resolved;
+}
+
+export async function ensureWorktree(
+	cachePath: string,
+	sha: string,
+	worktreePath: string,
+): Promise<{ reused: boolean }> {
+	if (await exists(worktreePath)) {
+		return { reused: true };
+	}
+	await mkdir(dirname(worktreePath), { recursive: true });
+	const proc = Bun.spawn(["git", "worktree", "add", worktreePath, sha], {
+		cwd: cachePath,
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const exitCode = await proc.exited;
+	// If `git worktree add` failed, it may be because a concurrent call won the race.
+	// Re-check the path: if still missing, it's a real failure.
+	if (exitCode !== 0 && !(await exists(worktreePath))) {
+		throw new MegasthenesError("clone_failed", `git worktree add failed with exit code ${exitCode}`, {
+			retryability: "yes",
+		});
+	}
+	return { reused: exitCode !== 0 };
+}
+
+// Stderr substrings that indicate there was nothing to remove: git already
+// doesn't track the worktree, or the path is gone. Matching any of these
+// means the desired end-state is already achieved, so removal is treated as
+// successful (idempotent remove) rather than failed.
+const CLEANUP_ALREADY_DONE_MARKERS = ["is not a working tree", "No such file or directory"] as const;
+
+export type RemoveWorktreeResult = { ok: true } | { ok: false; exitCode: number; stderr: string };
+
+/**
+ * Run `git worktree remove --force` for `worktreePath` against the bare cache at
+ * `cachePath`. Returns a structured result so callers can map outcomes without
+ * inspecting git internals.
+ *
+ * Idempotent: if git reports the worktree is already gone (see
+ * `CLEANUP_ALREADY_DONE_MARKERS`), the result is `{ ok: true }`.
+ */
+export async function removeWorktree(cachePath: string, worktreePath: string): Promise<RemoveWorktreeResult> {
+	const proc = Bun.spawn(["git", "worktree", "remove", "--force", worktreePath], {
+		cwd: cachePath,
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const [exitCode, stderr] = await Promise.all([proc.exited, new Response(proc.stderr).text()]);
+	if (exitCode === 0) return { ok: true };
+	if (CLEANUP_ALREADY_DONE_MARKERS.some((marker) => stderr.includes(marker))) {
+		return { ok: true };
+	}
+	return { ok: false, exitCode, stderr: stderr.trim() };
+}

--- a/src/forge/providers.ts
+++ b/src/forge/providers.ts
@@ -1,0 +1,57 @@
+import { MegasthenesError } from "../errors";
+
+/** Supported git forge types */
+export type ForgeName = "github" | "gitlab";
+
+/** Interface for git forge implementations */
+export interface Forge {
+	/** The forge identifier */
+	name: ForgeName;
+	/** Build an authenticated clone URL */
+	buildCloneUrl(repoUrl: string, token?: string): string;
+}
+
+export const GitHubForge: Forge = {
+	name: "github",
+	buildCloneUrl(repoUrl: string, token?: string): string {
+		if (!token) return repoUrl;
+		const url = new URL(repoUrl);
+		url.username = token;
+		return url.toString();
+	},
+};
+
+export const GitLabForge: Forge = {
+	name: "gitlab",
+	buildCloneUrl(repoUrl: string, token?: string): string {
+		if (!token) return repoUrl;
+		const url = new URL(repoUrl);
+		url.username = "oauth2";
+		url.password = token;
+		return url.toString();
+	},
+};
+
+export const forges: Record<ForgeName, Forge> = {
+	github: GitHubForge,
+	gitlab: GitLabForge,
+};
+
+export function inferForge(repoUrl: string): ForgeName | null {
+	const url = new URL(repoUrl);
+	if (url.hostname === "github.com") return "github";
+	if (url.hostname === "gitlab.com") return "gitlab";
+	return null;
+}
+
+export function parseRepoPath(repoUrl: string): { username: string; reponame: string } {
+	const url = new URL(repoUrl);
+	const parts = url.pathname
+		.replace(/^\//, "")
+		.replace(/\.git$/, "")
+		.split("/");
+	if (parts.length < 2 || !parts[0] || !parts[1]) {
+		throw new MegasthenesError("invalid_config", `Invalid repo URL: ${repoUrl}`, { retryability: "no" });
+	}
+	return { username: parts[0], reponame: parts[1] };
+}

--- a/test/forge-internals.test.ts
+++ b/test/forge-internals.test.ts
@@ -72,9 +72,9 @@ describe("forge internals", () => {
 			// Also detach the HEAD-side commit from local refs by resetting the default branch
 			// pointer to v1.0 so commit2 is unreachable locally until we fetch.
 			// For a bare repo, update refs to point at commit1 for every local branch.
-			const branches = (await git(cachePath, "for-each-ref", "--format=%(refname)", "refs/heads/")).split("\n").filter(
-				Boolean,
-			);
+			const branches = (await git(cachePath, "for-each-ref", "--format=%(refname)", "refs/heads/"))
+				.split("\n")
+				.filter(Boolean);
 			for (const ref of branches) {
 				await git(cachePath, "update-ref", ref, testRepo.commits[0] as string);
 			}

--- a/test/forge-internals.test.ts
+++ b/test/forge-internals.test.ts
@@ -1,0 +1,239 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ensureCachedRepo, removeWorktree, withCloneLock } from "../src/forge/git";
+import { createTestRepo, git, type TestRepo } from "./helpers/git";
+
+// Count git processes started while running a closure by wrapping Bun.spawn.
+// Verifies "no network call" for ensureCachedRepo's reuse-cache branch.
+function countGitSpawnsDuring<T>(fn: () => Promise<T>): Promise<{ result: T; spawns: string[][] }> {
+	const originalSpawn = Bun.spawn.bind(Bun) as typeof Bun.spawn;
+	const spawns: string[][] = [];
+	// Bun.spawn has multiple overloads — we only care about the array form git uses here.
+	(Bun as unknown as { spawn: typeof Bun.spawn }).spawn = ((cmd: unknown, opts?: unknown) => {
+		if (Array.isArray(cmd) && typeof cmd[0] === "string" && cmd[0] === "git") {
+			spawns.push(cmd as string[]);
+		}
+		return (originalSpawn as unknown as (c: unknown, o?: unknown) => ReturnType<typeof Bun.spawn>)(cmd, opts);
+	}) as typeof Bun.spawn;
+	return fn()
+		.then((result) => ({ result, spawns }))
+		.finally(() => {
+			(Bun as unknown as { spawn: typeof Bun.spawn }).spawn = originalSpawn;
+		});
+}
+
+describe("forge internals", () => {
+	let workRoot: string;
+	let testRepo: TestRepo;
+
+	beforeAll(async () => {
+		workRoot = await mkdtemp(join(tmpdir(), "forge-internals-"));
+		testRepo = await createTestRepo(join(workRoot, "remote"));
+	});
+
+	afterAll(async () => {
+		await rm(workRoot, { recursive: true, force: true });
+	});
+
+	describe("ensureCachedRepo", () => {
+		test("cache exists AND commitish present locally → reuse_cache, no network call", async () => {
+			const cachePath = join(workRoot, "cache-reuse");
+			// Seed the cache with an initial clone.
+			const seed = await ensureCachedRepo(cachePath, "HEAD", () => testRepo.url);
+			expect(seed.operation).toBe("clone");
+
+			// Second call for a commitish that already resolves locally must not spawn git fetch/clone.
+			const { result, spawns } = await countGitSpawnsDuring(() =>
+				ensureCachedRepo(cachePath, testRepo.commits[0] as string, () => {
+					throw new Error("buildCloneUrl should not be called when reusing cache");
+				}),
+			);
+
+			expect(result).toEqual({ operation: "reuse_cache", cacheExisted: true });
+			// Only allowed spawn: git cat-file -t <commitish> (the existence probe).
+			for (const cmd of spawns) {
+				expect(cmd.slice(0, 3)).toEqual(["git", "cat-file", "-t"]);
+			}
+		});
+
+		test("cache exists AND commitish missing → fetch", async () => {
+			const cachePath = join(workRoot, "cache-fetch");
+			// Start from a clone that does NOT have the later commit: make a separate bare repo
+			// with only the first commit, clone it, then push the second commit to the original
+			// bare repo (upstream) so a fetch from the cache's origin will actually bring in data.
+			// Simpler: clone the real remote, then force-delete its ref to v2.0 locally so it's missing.
+			await ensureCachedRepo(cachePath, "v1.0", () => testRepo.url);
+
+			// Make sure the cache now lacks a ref that origin has: delete the v2.0 tag locally.
+			await git(cachePath, "tag", "-d", "v2.0");
+			// Also detach the HEAD-side commit from local refs by resetting the default branch
+			// pointer to v1.0 so commit2 is unreachable locally until we fetch.
+			// For a bare repo, update refs to point at commit1 for every local branch.
+			const branches = (await git(cachePath, "for-each-ref", "--format=%(refname)", "refs/heads/")).split("\n").filter(
+				Boolean,
+			);
+			for (const ref of branches) {
+				await git(cachePath, "update-ref", ref, testRepo.commits[0] as string);
+			}
+			// GC would be too aggressive; we only need cat-file to fail for commit2. Since commit2
+			// is still present as an object but the test below asks for v2.0 (which we deleted),
+			// cat-file -t v2.0 returns non-zero → forces the fetch branch.
+
+			const result = await ensureCachedRepo(cachePath, "v2.0", () => testRepo.url);
+			expect(result).toEqual({ operation: "fetch", cacheExisted: true });
+
+			// After fetch, v2.0 must be resolvable.
+			const afterTag = await git(cachePath, "rev-parse", "v2.0");
+			expect(afterTag).toBe(testRepo.commits[1] as string);
+		});
+
+		test("cache directory absent → clone", async () => {
+			const cachePath = join(workRoot, "cache-clone");
+			expect(existsSync(cachePath)).toBe(false);
+
+			const result = await ensureCachedRepo(cachePath, "HEAD", () => testRepo.url);
+
+			expect(result).toEqual({ operation: "clone", cacheExisted: false });
+			expect(existsSync(join(cachePath, "HEAD"))).toBe(true);
+		});
+
+		test("cache dir exists but HEAD missing → cleanup + reclone", async () => {
+			const cachePath = join(workRoot, "cache-incomplete");
+			// Simulate an incomplete prior clone: dir exists, HEAD does not, with a stray file
+			// we can verify gets cleaned up.
+			await mkdir(cachePath, { recursive: true });
+			const strayPath = join(cachePath, "stray-file");
+			await writeFile(strayPath, "leftover from failed clone");
+			expect(existsSync(strayPath)).toBe(true);
+
+			const result = await ensureCachedRepo(cachePath, "HEAD", () => testRepo.url);
+
+			expect(result).toEqual({ operation: "clone", cacheExisted: false });
+			expect(existsSync(strayPath)).toBe(false);
+			expect(existsSync(join(cachePath, "HEAD"))).toBe(true);
+		});
+	});
+
+	describe("withCloneLock", () => {
+		test("concurrent same-key callers are serialized (observe ordering)", async () => {
+			const order: string[] = [];
+			const firstStarted = Promise.withResolvers<void>();
+			const releaseFirst = Promise.withResolvers<void>();
+			let secondStarted = false;
+
+			const p1 = withCloneLock("key-A", async () => {
+				order.push("start-1");
+				firstStarted.resolve();
+				await releaseFirst.promise;
+				order.push("end-1");
+				return 1;
+			});
+			const p2 = withCloneLock("key-A", async () => {
+				secondStarted = true;
+				order.push("start-2");
+				order.push("end-2");
+				return 2;
+			});
+
+			await firstStarted.promise;
+			// While the first holds the lock, the second must not have entered its body.
+			expect(order).toEqual(["start-1"]);
+			expect(secondStarted).toBe(false);
+
+			releaseFirst.resolve();
+			const [r1, r2] = await Promise.all([p1, p2]);
+
+			expect(r1).toBe(1);
+			expect(r2).toBe(2);
+			expect(order).toEqual(["start-1", "end-1", "start-2", "end-2"]);
+		});
+
+		test("lock is released when fn throws (subsequent call proceeds)", async () => {
+			await expect(
+				withCloneLock("key-B", async () => {
+					throw new Error("boom");
+				}),
+			).rejects.toThrow("boom");
+
+			// If the lock were not released, this call would deadlock; bun:test would time out.
+			const v = await withCloneLock("key-B", async () => "ok");
+			expect(v).toBe("ok");
+		});
+
+		test("different keys do not block each other", async () => {
+			const order: string[] = [];
+			const aStarted = Promise.withResolvers<void>();
+			const releaseA = Promise.withResolvers<void>();
+
+			const pA = withCloneLock("key-C", async () => {
+				order.push("start-A");
+				aStarted.resolve();
+				await releaseA.promise;
+				order.push("end-A");
+				return "A";
+			});
+
+			await aStarted.promise;
+
+			// Different key must run to completion while A is still held.
+			const bResult = await withCloneLock("key-D", async () => {
+				order.push("start-B");
+				order.push("end-B");
+				return "B";
+			});
+			expect(bResult).toBe("B");
+			expect(order).toEqual(["start-A", "start-B", "end-B"]);
+
+			releaseA.resolve();
+			await pA;
+			expect(order).toEqual(["start-A", "start-B", "end-B", "end-A"]);
+		});
+	});
+
+	describe("removeWorktree", () => {
+		test("success → { ok: true }", async () => {
+			const cachePath = join(workRoot, "remove-success");
+			await ensureCachedRepo(cachePath, "HEAD", () => testRepo.url);
+			const worktreePath = join(workRoot, "remove-success-tree");
+			await git(cachePath, "worktree", "add", worktreePath, "HEAD");
+			expect(existsSync(worktreePath)).toBe(true);
+
+			const result = await removeWorktree(cachePath, worktreePath);
+
+			expect(result).toEqual({ ok: true });
+			expect(existsSync(worktreePath)).toBe(false);
+		});
+
+		test("already-done marker → { ok: true } (idempotent)", async () => {
+			const cachePath = join(workRoot, "remove-idempotent");
+			await ensureCachedRepo(cachePath, "HEAD", () => testRepo.url);
+			const worktreePath = join(workRoot, "remove-idempotent-tree");
+			await git(cachePath, "worktree", "add", worktreePath, "HEAD");
+
+			const first = await removeWorktree(cachePath, worktreePath);
+			expect(first).toEqual({ ok: true });
+
+			// Second removal: git will emit "is not a working tree" — must be classified as ok.
+			const second = await removeWorktree(cachePath, worktreePath);
+			expect(second).toEqual({ ok: true });
+		});
+
+		test("real failure → { ok: false, exitCode, stderr }", async () => {
+			// cachePath points at a non-git directory → git errors with "not a git repository".
+			const nonGitDir = await mkdtemp(join(tmpdir(), "forge-internals-nongit-"));
+			try {
+				const result = await removeWorktree(nonGitDir, join(nonGitDir, "nope"));
+				expect(result.ok).toBe(false);
+				if (result.ok) throw new Error("unreachable");
+				expect(typeof result.exitCode).toBe("number");
+				expect(result.exitCode).not.toBe(0);
+				expect(result.stderr).toMatch(/not a git repository/i);
+			} finally {
+				await rm(nonGitDir, { recursive: true, force: true });
+			}
+		});
+	});
+});

--- a/test/forge.test.ts
+++ b/test/forge.test.ts
@@ -6,6 +6,7 @@ import { join, resolve } from "node:path";
 import { MegasthenesError } from "../src/errors";
 import { cleanupRepo, connectRepo, type Forge, inferForge, type Repo } from "../src/forge";
 import type { ErrorType } from "../src/types";
+import { createTestRepo } from "./helpers/git";
 
 // =============================================================================
 // Test Helpers
@@ -15,97 +16,6 @@ async function expectConnectError(promise: Promise<unknown>, errorType: ErrorTyp
 	const err = await promise.catch((e: unknown) => e);
 	expect(err).toBeInstanceOf(MegasthenesError);
 	expect((err as MegasthenesError).errorType).toBe(errorType);
-}
-
-interface TestRepo {
-	/** file:// URL to the bare repo */
-	url: string;
-	/** Path to the bare repo */
-	barePath: string;
-	/** SHA of each commit (index 0 = first commit) */
-	commits: string[];
-	/** Tag names created */
-	tags: string[];
-}
-
-/** Run a git command and return stdout */
-async function git(cwd: string, ...args: string[]): Promise<string> {
-	const proc = Bun.spawn(["git", ...args], {
-		cwd,
-		stdout: "pipe",
-		stderr: "pipe",
-		env: {
-			...process.env,
-			// Prevent git from prompting
-			GIT_TERMINAL_PROMPT: "0",
-			// Set committer info for test commits
-			GIT_AUTHOR_NAME: "Test",
-			GIT_AUTHOR_EMAIL: "test@test.com",
-			GIT_COMMITTER_NAME: "Test",
-			GIT_COMMITTER_EMAIL: "test@test.com",
-		},
-	});
-	const stdout = await new Response(proc.stdout).text();
-	const exitCode = await proc.exited;
-	if (exitCode !== 0) {
-		const stderr = await new Response(proc.stderr).text();
-		throw new Error(`git ${args.join(" ")} failed: ${stderr}`);
-	}
-	return stdout.trim();
-}
-
-/**
- * Create a test git repository with commits and tags.
- * Returns a file:// URL that can be used with connectRepo.
- *
- * The repo is structured as user/repo to match expected URL parsing.
- */
-async function createTestRepo(baseDir: string): Promise<TestRepo> {
-	// Structure as user/repo.git to match expected URL format
-	const barePath = join(baseDir, "testuser", "testrepo.git");
-	const workPath = join(baseDir, "work");
-
-	await mkdir(join(baseDir, "testuser"), { recursive: true });
-
-	// Create bare repo (acts as remote)
-	await mkdir(barePath, { recursive: true });
-	await git(barePath, "init", "--bare");
-
-	// Clone to working directory
-	await git(baseDir, "clone", barePath, "work");
-
-	const commits: string[] = [];
-	const tags: string[] = [];
-
-	// Create first commit
-	await Bun.write(join(workPath, "README.md"), "# Test Repo\n\nVersion 1");
-	await git(workPath, "add", ".");
-	await git(workPath, "commit", "-m", "Initial commit");
-	commits.push(await git(workPath, "rev-parse", "HEAD"));
-
-	// Create tag v1.0
-	await git(workPath, "tag", "v1.0");
-	tags.push("v1.0");
-
-	// Create second commit
-	await Bun.write(join(workPath, "README.md"), "# Test Repo\n\nVersion 2");
-	await git(workPath, "add", ".");
-	await git(workPath, "commit", "-m", "Second commit");
-	commits.push(await git(workPath, "rev-parse", "HEAD"));
-
-	// Create tag v2.0
-	await git(workPath, "tag", "v2.0");
-	tags.push("v2.0");
-
-	// Push to bare repo (use HEAD to push current branch regardless of name)
-	await git(workPath, "push", "origin", "HEAD", "--tags");
-
-	return {
-		url: `file://${barePath}`,
-		barePath,
-		commits,
-		tags,
-	};
 }
 
 // =============================================================================

--- a/test/git.test.ts
+++ b/test/git.test.ts
@@ -25,12 +25,12 @@ function countGitSpawnsDuring<T>(fn: () => Promise<T>): Promise<{ result: T; spa
 		});
 }
 
-describe("forge internals", () => {
+describe("forge/git", () => {
 	let workRoot: string;
 	let testRepo: TestRepo;
 
 	beforeAll(async () => {
-		workRoot = await mkdtemp(join(tmpdir(), "forge-internals-"));
+		workRoot = await mkdtemp(join(tmpdir(), "forge-git-"));
 		testRepo = await createTestRepo(join(workRoot, "remote"));
 	});
 
@@ -223,7 +223,7 @@ describe("forge internals", () => {
 
 		test("real failure → { ok: false, exitCode, stderr }", async () => {
 			// cachePath points at a non-git directory → git errors with "not a git repository".
-			const nonGitDir = await mkdtemp(join(tmpdir(), "forge-internals-nongit-"));
+			const nonGitDir = await mkdtemp(join(tmpdir(), "forge-git-nongit-"));
 			try {
 				const result = await removeWorktree(nonGitDir, join(nonGitDir, "nope"));
 				expect(result.ok).toBe(false);

--- a/test/helpers/git.ts
+++ b/test/helpers/git.ts
@@ -1,0 +1,93 @@
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+
+export interface TestRepo {
+	/** file:// URL to the bare repo */
+	url: string;
+	/** Path to the bare repo */
+	barePath: string;
+	/** SHA of each commit (index 0 = first commit) */
+	commits: string[];
+	/** Tag names created */
+	tags: string[];
+}
+
+/** Run a git command and return stdout */
+export async function git(cwd: string, ...args: string[]): Promise<string> {
+	const proc = Bun.spawn(["git", ...args], {
+		cwd,
+		stdout: "pipe",
+		stderr: "pipe",
+		env: {
+			...process.env,
+			// Prevent git from prompting
+			GIT_TERMINAL_PROMPT: "0",
+			// Set committer info for test commits
+			GIT_AUTHOR_NAME: "Test",
+			GIT_AUTHOR_EMAIL: "test@test.com",
+			GIT_COMMITTER_NAME: "Test",
+			GIT_COMMITTER_EMAIL: "test@test.com",
+		},
+	});
+	const stdout = await new Response(proc.stdout).text();
+	const exitCode = await proc.exited;
+	if (exitCode !== 0) {
+		const stderr = await new Response(proc.stderr).text();
+		throw new Error(`git ${args.join(" ")} failed: ${stderr}`);
+	}
+	return stdout.trim();
+}
+
+/**
+ * Create a test git repository with commits and tags.
+ * Returns a file:// URL that can be used with connectRepo.
+ *
+ * The repo is structured as user/repo to match expected URL parsing.
+ */
+export async function createTestRepo(baseDir: string): Promise<TestRepo> {
+	// Structure as user/repo.git to match expected URL format
+	const barePath = join(baseDir, "testuser", "testrepo.git");
+	const workPath = join(baseDir, "work");
+
+	await mkdir(join(baseDir, "testuser"), { recursive: true });
+
+	// Create bare repo (acts as remote)
+	await mkdir(barePath, { recursive: true });
+	await git(barePath, "init", "--bare");
+
+	// Clone to working directory
+	await git(baseDir, "clone", barePath, "work");
+
+	const commits: string[] = [];
+	const tags: string[] = [];
+
+	// Create first commit
+	await Bun.write(join(workPath, "README.md"), "# Test Repo\n\nVersion 1");
+	await git(workPath, "add", ".");
+	await git(workPath, "commit", "-m", "Initial commit");
+	commits.push(await git(workPath, "rev-parse", "HEAD"));
+
+	// Create tag v1.0
+	await git(workPath, "tag", "v1.0");
+	tags.push("v1.0");
+
+	// Create second commit
+	await Bun.write(join(workPath, "README.md"), "# Test Repo\n\nVersion 2");
+	await git(workPath, "add", ".");
+	await git(workPath, "commit", "-m", "Second commit");
+	commits.push(await git(workPath, "rev-parse", "HEAD"));
+
+	// Create tag v2.0
+	await git(workPath, "tag", "v2.0");
+	tags.push("v2.0");
+
+	// Push to bare repo (use HEAD to push current branch regardless of name)
+	await git(workPath, "push", "origin", "HEAD", "--tags");
+
+	return {
+		url: `file://${barePath}`,
+		barePath,
+		commits,
+		tags,
+	};
+}


### PR DESCRIPTION
## Summary

- Splits `src/forge.ts` (361 lines) into three files along one-reason-to-change axes: `src/forge/providers.ts` (forge table + URL parsing/inference), `src/forge/git.ts` (git subprocess helpers + module-private clone-lock), and a shrunken `src/forge.ts` (public API + orchestrator).
- Adds `test/forge-internals.test.ts` with comprehensive branch-coverage tests for `ensureCachedRepo` (4 branches), `withCloneLock` (3 scenarios, gate-based coordination — no `Bun.sleep`), and `removeWorktree` (3 outcomes).
- Extracts shared `createTestRepo` / `git` helpers into `test/helpers/git.ts` so the two forge test files don't duplicate them.
- No behavior changes. Public API preserved; `src/index.ts` and `src/session.ts` require no edits.

Planning doc (`PLAN.md`) kept out of this PR intentionally — it's a scratch artifact, not a deliverable.

## Test plan

- [x] `bunx tsc --noEmit` — clean
- [x] `bun test` — 380 pass / 3 fail; the 3 failures are pre-existing `sandbox git tool` integration tests unrelated to this refactor (reproduce on `main`)
- [x] `test/forge-internals.test.ts` — all 10 new branch-coverage tests pass in isolation and in the full suite
- [ ] Verify `src/index.ts` and `src/session.ts` still compile against the new surface (covered by `tsc` above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)