### PR TITLE
fix(session): make SessionConfig.compaction match runtime behavior

### DIFF
--- a/docs/src/content/docs/guides/configuration.md
+++ b/docs/src/content/docs/guides/configuration.md
@@ -196,7 +196,32 @@ Thinking can also be overridden per `ask()` — see [API Keys and Providers](/me
 
 ### Context Compaction
 
-When conversations grow long, megasthenes automatically summarizes older messages to stay within the model's context window. Compaction is enabled by default.
+When conversations grow long, megasthenes automatically summarizes older messages to stay within the model's context window. Compaction is enabled by default — set `compaction: { enabled: false }` to opt out, or override individual fields to tune when it fires. Any fields you leave unset fall back to the defaults shown below.
+
+```ts
+// Opt out entirely
+await client.connect({
+  repo: { url: "https://github.com/owner/repo" },
+  model: { provider: "anthropic", id: "claude-sonnet-4-6" },
+  maxIterations: 20,
+  compaction: { enabled: false },
+});
+
+// Tune the thresholds (e.g. for a 1M-context model)
+await client.connect({
+  repo: { url: "https://github.com/owner/repo" },
+  model: { provider: "anthropic", id: "claude-sonnet-4-6" },
+  maxIterations: 20,
+  compaction: {
+    enabled: true,              // default: true
+    contextWindow: 1_000_000,   // default: 200_000 — total usable context
+    reserveTokens: 16_384,      // default: 16_384 — tokens held back for the response
+    keepRecentTokens: 20_000,   // default: 20_000 — recent messages kept unsummarized
+  },
+});
+```
+
+Compaction fires when estimated context tokens exceed `contextWindow - reserveTokens`. The most recent messages totalling roughly `keepRecentTokens` are retained verbatim; everything before that is replaced with an LLM-generated summary. See the [`compaction` event in Handling Responses](/megasthenes/guides/handling-responses/) for how to observe it at runtime.
 
 ### Tracing
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,8 +85,14 @@ export interface SessionConfig {
 	maxIterations: number;
 	/** Thinking/reasoning configuration. If omitted, thinking is off. */
 	thinking?: ThinkingConfig;
-	/** Context compaction settings. If omitted, compaction is off. */
-	compaction?: CompactionSettings;
+	/**
+	 * Context compaction settings. Compaction is on by default — pass
+	 * `{ enabled: false }` to opt out, or override individual fields
+	 * (`contextWindow`, `reserveTokens`, `keepRecentTokens`) to tune when
+	 * compaction fires. Unset fields fall back to built-in defaults
+	 * (200K context window, 16K reserve, 20K recent-keep).
+	 */
+	compaction?: Partial<CompactionSettings>;
 	/** Prior turns to seed the session with. Restores LLM context from previous conversation. */
 	initialTurns?: TurnResult[];
 	/** Last compaction summary from a prior session. Required for compaction continuity when restoring with initialTurns. */

--- a/test/compaction.test.ts
+++ b/test/compaction.test.ts
@@ -592,4 +592,26 @@ describe("Session compaction integration", () => {
 
 		expect(events.find((e) => e.type === "compaction")).toBeDefined();
 	});
+
+	test("config.compaction.enabled=false suppresses compaction even when the threshold is crossed", async () => {
+		// Same threshold-crushing settings as the trigger-compaction test above —
+		// if `enabled: false` weren't threaded through, this would compact.
+		const session = new Session(createMockRepo(), {
+			model: {} as Model<Api>,
+			systemPrompt: "You are a test assistant",
+			tools: [],
+			maxIterations: 5,
+			executeTool: async () => "mock",
+			logger: nullLogger,
+			stream: createSessionMockStream(),
+			compaction: { enabled: false, contextWindow: 0, reserveTokens: 0, keepRecentTokens: 1 },
+		});
+
+		const events: StreamEvent[] = [];
+		for await (const ev of session.ask("anything")) {
+			events.push(ev);
+		}
+
+		expect(events.find((e) => e.type === "compaction")).toBeUndefined();
+	});
 });


### PR DESCRIPTION
Closes #158.

## Summary

`SessionConfig.compaction` was a partially-wired public API: the type required all four fields, the docstring claimed compaction was off by default, and neither matched the runtime (on by default, one-field overrides are the natural use case). The runtime wiring itself — `maybeCompact` accepting `Partial<CompactionSettings>` and `Session.#runCompaction` threading `this.#config.compaction` through — already landed on main. This PR finishes the remaining items.

- **`src/index.ts`** — widen `compaction?` to `Partial<CompactionSettings>` so `{ enabled: false }` and individual-knob overrides type-check, and rewrite the docstring to describe actual behavior (on by default; unset fields fall back to built-in defaults).
- **`test/compaction.test.ts`** — add a Session-level integration test asserting `enabled: false` suppresses compaction even when the threshold is crossed. Parallel to the existing `contextWindow`-flows-through test.
- **`docs/src/content/docs/guides/configuration.md`** — restore the tunable-knobs example that was trimmed to "enabled by default" while this bug was open, with separate opt-out and threshold-override blocks and a when-it-fires note.

## Test plan

- [x] `bun test test/compaction.test.ts` — 32 pass, 0 fail
- [x] `bun test test/compaction.test.ts test/session.test.ts test/tracing.test.ts` — 111 pass, 0 fail
- [x] `bunx tsc --noEmit` — clean
- [x] `bunx biome check` on changed files — clean
- [ ] Eyeball the rendered Context Compaction section on the docs site after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)