### PR TITLE
fix(git): drop --filter=blob:none so history reads work in sandbox

### DIFF
--- a/docs/src/content/docs/guides/observability.md
+++ b/docs/src/content/docs/guides/observability.md
@@ -79,7 +79,7 @@ This span is where local clone/fetch/worktree work or sandbox clone work is reco
 Local child span covering:
 - cache hit / cache reuse
 - `git fetch` when the requested commitish is missing locally
-- fresh `git clone --bare --filter=blob:none`
+- fresh `git clone --bare`
 
 ### `repo.resolve_commitish`
 

--- a/src/forge.ts
+++ b/src/forge.ts
@@ -94,7 +94,6 @@ function recordCachePhaseOutcome(span: Span | undefined, cachePath: string, resu
 	endChildSpan(span, {
 		...base,
 		"megasthenes.git.operation": "clone",
-		"megasthenes.git.clone.filter": "blob:none",
 	});
 }
 

--- a/src/forge/git.ts
+++ b/src/forge/git.ts
@@ -99,7 +99,7 @@ export async function ensureCachedRepo(
 		await rm(cachePath, { recursive: true, force: true });
 	}
 	await mkdir(cachePath, { recursive: true });
-	const proc = Bun.spawn(["git", "clone", "--bare", "--filter=blob:none", buildCloneUrl(), cachePath], {
+	const proc = Bun.spawn(["git", "clone", "--bare", buildCloneUrl(), cachePath], {
 		stdout: "inherit",
 		stderr: "inherit",
 	});

--- a/src/sandbox/worker.ts
+++ b/src/sandbox/worker.ts
@@ -265,7 +265,7 @@ async function executeClone(jobKey: string, url: string, commitish: string): Pro
 			}
 		} else {
 			const { exitCode, stderr } = await runGitIsolated(
-				["clone", "--bare", "--filter=blob:none", url, bareDir],
+				["clone", "--bare", url, bareDir],
 				undefined,
 				baseDir,
 				CLONE_TIMEOUT_MS,

--- a/test/sandbox/sandbox.integration.test.ts
+++ b/test/sandbox/sandbox.integration.test.ts
@@ -540,7 +540,7 @@ describe("sandbox git tool", () => {
 		expect(output).toContain("Author:");
 	});
 
-	test("git show reports a clear partial clone error when objects are missing", async () => {
+	test("git show --stat produces diff stats against a full clone", async () => {
 		if (!(await isSandboxRunning())) return;
 
 		const output = await client.executeTool(cloneResult.slug, cloneResult.sha, "git", {
@@ -548,19 +548,18 @@ describe("sandbox git tool", () => {
 			args: ["--stat", "-1"],
 		});
 
-		expect(output).toContain("needs objects omitted by partial clone");
-		expect(output).not.toContain("promisor remote");
+		expect(output).toContain("Author:");
+		expect(output).toMatch(/\d+ file.* changed/);
 	});
 
-	test("git blame reports a clear partial clone error when objects are missing", async () => {
+	test("git blame attributes lines against a full clone", async () => {
 		if (!(await isSandboxRunning())) return;
 
 		const output = await client.executeTool(cloneResult.slug, cloneResult.sha, "git", {
 			command: "blame",
 			args: ["README"],
 		});
-		expect(output).toContain("needs objects omitted by partial clone");
-		expect(output).not.toContain("promisor remote");
+		expect(output).toMatch(/\(.+\d{4}-\d{2}-\d{2}/);
 	});
 
 	test("git fetch is blocked", async () => {


### PR DESCRIPTION
## Summary

- Remove `--filter=blob:none` from both clone call sites (host-side cache clone in `src/forge/git.ts`, sandbox clone in `src/sandbox/worker.ts`)
- Drop the now-inaccurate `megasthenes.git.clone.filter` span attribute and update the observability doc
- Replace two sandbox integration tests that asserted the old partial-clone error surface with positive tests that exercise `show --stat` and `blame` against a full clone

Closes #163.

## Why

The sandbox combines partial clone with `GIT_NO_LAZY_FETCH=1` and a network-blocking seccomp filter, so any git command that touches a blob outside the checked-out SHA (`blame`, `log -p`, `show <sha>:path`, `diff <a>..<b>`) fails. The agent's core value is repo archaeology, so the clone-size savings from partial clone don't pay for the lost functionality. See #162 for the per-subcommand analysis and #146 for the sandbox-integration angle.

## Scope notes

- `isMissingPromisorObjectError` and the associated error-rewrite in `worker.ts` are **kept** as defensive scaffolding. #162's tradeoff analysis leaves the door open for a future `--filter=blob:limit=<size>` reintroduction, at which point the rewrite becomes useful again.
- Two pre-existing test failures (`git fetch is blocked`, `git push is blocked`) are unrelated to this change — they fail because the git tool's command schema rejects `fetch`/`push` at the validation layer before the runtime error message ("not allowed") can be produced. Leaving them alone; out of scope for #163.

## Test plan

- [x] `rg 'blob:none|blobless'` returns no matches post-change
- [x] `bunx tsc --noEmit` clean
- [x] `bunx biome check` clean on all modified files
- [x] `bun test` — 396 pass, 4 fail (same 4 that fail on `main` pre-change; 2 are the updated positive tests awaiting a sandbox-image rebuild, 2 are unrelated pre-existing failures)
- [ ] Rebuild sandbox image and spot-check `blame`, `log -p`, `show <sha>:path`, `diff <a>..<b>` work end-to-end (requires docker; CI will exercise this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)