### PR TITLE
docs(handling-responses): warn about unconsumed-stream footgun

### DIFF
--- a/docs/src/content/docs/guides/handling-responses.md
+++ b/docs/src/content/docs/guides/handling-responses.md
@@ -147,5 +147,5 @@ for await (const event of stream) {
 
 - **Lazy start**: The stream does not begin until you consume it (iterate or call `.result()`).
 - **Single consumption**: A stream can only be iterated once. Attempting to iterate again throws `"AskStream is already being consumed"`.
-- **Serialized asks**: Concurrent `ask()` calls on the same session are serialized — each waits for the previous to complete.
+- **Serialized asks**: Concurrent `ask()` calls on the same session are serialized — each waits for the previous to complete. Because streams are also lazy, an `AskStream` you create but never consume will block every subsequent `ask()` on the session indefinitely. Always iterate or `await .result()` on every stream you create — even if you only want to discard it (`await session.ask("...").result().catch(() => {})`). If you need true parallelism, use separate sessions.
 - **Cacheable result**: `.result()` can be called multiple times — subsequent calls return the cached `TurnResult`.


### PR DESCRIPTION
## Summary
- `handling-responses.md` already notes that streams are lazy and `ask()` calls are serialized, but as separate bullets. The interaction is the real footgun: an `AskStream` you create but never consume stalls every subsequent `ask()` on the session forever.
- Extend the **Serialized asks** bullet with the combined warning, show the `.result().catch(() => {})` discard pattern, and point at separate sessions for true parallelism.

## Test plan
- [x] `cd docs && bun run dev`, open `/guides/handling-responses/`, confirm the Behavior Notes bullet renders with the new guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)