### PR TITLE
docs: fix pi-ai package path in upstream links

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Megasthenes allows you to programmatically ask questions to a GitHub/GitLab repo
 
 - 🔗 **Ask questions about any GitHub/GitLab repository**: Point it at any public or private repository URL and start asking questions in plain language.
 - 📌 **Query any point in history**: Pin your question to a specific branch, tag, or commit
-- 🤖 **Configurable**: Choose any model and provider supported by [`pi-ai`](https://github.com/badlogic/pi-mono/blob/main/packages/pi-ai/src/models.generated.ts) (OpenRouter, Anthropic, Google, and more). Customize the system prompt, tool iteration limits, and context compaction settings.
+- 🤖 **Configurable**: Choose any model and provider supported by [`pi-ai`](https://github.com/badlogic/pi-mono/blob/main/packages/ai/src/models.generated.ts) (OpenRouter, Anthropic, Google, and more). Customize the system prompt, tool iteration limits, and context compaction settings.
 - 🔒 **Sandboxed execution**: Run tool execution (file reads, code search) in an isolated container for exploring untrusted repositories safely
 - 📊 **Rich answer metadata**: Every response includes token usage, timing, and a complete record of all tool calls the model made.
 - 📡 **OpenTelemetry observability**: Built-in tracing with GenAI semantic conventions — send spans to Langfuse, Jaeger, or any OTel-compatible backend. Zero overhead when no SDK is installed.

--- a/docs/src/content/docs/guides/api-keys-and-providers.md
+++ b/docs/src/content/docs/guides/api-keys-and-providers.md
@@ -43,8 +43,8 @@ await session.ask("Summarize the architecture.", {
 
 `maxIterations` and `thinking` can be overridden on a single `ask()` the same way — see [`AskOptions`][askopts].
 
-[pi-ai]: https://github.com/badlogic/pi-mono/tree/main/packages/pi-ai
-[models]: https://github.com/badlogic/pi-mono/blob/main/packages/pi-ai/src/models.generated.ts
-[pi-env]: https://github.com/badlogic/pi-mono/tree/main/packages/pi-ai#environment-variables-nodejs-only
-[pi-oauth]: https://github.com/badlogic/pi-mono/tree/main/packages/pi-ai#oauth-providers
+[pi-ai]: https://github.com/badlogic/pi-mono/tree/main/packages/ai
+[models]: https://github.com/badlogic/pi-mono/blob/main/packages/ai/src/models.generated.ts
+[pi-env]: https://github.com/badlogic/pi-mono/tree/main/packages/ai#environment-variables-nodejs-only
+[pi-oauth]: https://github.com/badlogic/pi-mono/tree/main/packages/ai#oauth-providers
 [askopts]: /megasthenes/api/interfaces/askoptions/

--- a/docs/src/content/docs/start-here/getting-started.md
+++ b/docs/src/content/docs/start-here/getting-started.md
@@ -11,7 +11,7 @@ megasthenes is a TypeScript library that lets you programmatically ask questions
 
 - **Ask questions about any repository** — Point it at any public or private repository URL and start asking questions in plain language.
 - **Query any point in history** — Pin your question to a specific branch, tag, or commit.
-- **Configurable** — Choose any model and provider supported by [pi-ai](https://github.com/badlogic/pi-mono/blob/main/packages/pi-ai/src/models.generated.ts) (OpenRouter, Anthropic, Google, and more). Customize the system prompt, tool iteration limits, and context compaction settings.
+- **Configurable** — Choose any model and provider supported by [pi-ai](https://github.com/badlogic/pi-mono/blob/main/packages/ai/src/models.generated.ts) (OpenRouter, Anthropic, Google, and more). Customize the system prompt, tool iteration limits, and context compaction settings.
 - **Sandboxed execution** — Run tool execution in an isolated container for exploring untrusted repositories safely.
 - **Rich answer metadata** — Every response includes token usage, timing, and a complete record of all tool calls the model made.
 - **OpenTelemetry observability** — All LLM calls and tool invocations are traced with GenAI semantic conventions.


### PR DESCRIPTION
## Summary
- Upstream links to pi-ai were pointing at `packages/pi-ai/` in the `pi-mono` monorepo, but the actual path is `packages/ai/` — the old URLs 404.
- Fix the four reference-style links in `api-keys-and-providers.md`, the Features list in `getting-started.md`, and the matching Features bullet in the root `README.md`.

## Test plan
- [x] Open each updated URL and confirm it resolves (models.generated.ts, the env-vars section, the OAuth providers section, the package root).
- [x] `cd docs && bun run dev`, visit `/start-here/getting-started/` and `/guides/api-keys-and-providers/`, click through the pi-ai links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)