### PR TITLE
docs: shell-prompt rendering and guide refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ Megasthenes allows you to programmatically ask questions to a GitHub/GitLab repo
 - 📡 **OpenTelemetry observability**: Built-in tracing with GenAI semantic conventions — send spans to Langfuse, Jaeger, or any OTel-compatible backend. Zero overhead when no SDK is installed.
 - 🧪 **Built-in evaluation system**: Measure and track answer quality over time using an LLM judge that scores responses on completeness, evidence, sourcing, and reasoning.
 
+## Documentation
+
+Full documentation is available at [nilenso.github.io/megasthenes](https://nilenso.github.io/megasthenes/) — configuration, sandboxing, observability, error handling, and the API reference.
+
 ## Requirements
 
 - [Bun](https://bun.sh/) (or Node.js ≥ 18)

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -1,6 +1,7 @@
 import starlight from "@astrojs/starlight";
 import { defineConfig } from "astro/config";
 import starlightTypeDoc, { typeDocSidebarGroup } from "starlight-typedoc";
+import { shellCommentMarker } from "./ec-plugins/shell-comment-marker.mjs";
 
 export default defineConfig({
 	site: "https://nilenso.github.io",
@@ -9,6 +10,9 @@ export default defineConfig({
 		starlight({
 			title: "megasthenes",
 			customCss: ["./src/styles/custom.css"],
+			expressiveCode: {
+				plugins: [shellCommentMarker()],
+			},
 			social: [
 				{
 					icon: "github",

--- a/docs/ec-plugins/shell-comment-marker.mjs
+++ b/docs/ec-plugins/shell-comment-marker.mjs
@@ -1,0 +1,16 @@
+import { addClassName } from "@expressive-code/core";
+
+const SHELL_LANGUAGES = new Set(["bash", "sh", "shell", "shellsession", "zsh"]);
+
+export function shellCommentMarker() {
+	return {
+		name: "shell-comment-marker",
+		hooks: {
+			postprocessRenderedLine: ({ codeBlock, line, renderData }) => {
+				if (!SHELL_LANGUAGES.has(codeBlock.language)) return;
+				if (!line.text.trimStart().startsWith("#")) return;
+				addClassName(renderData.lineAst, "is-shell-comment");
+			},
+		},
+	};
+}

--- a/docs/src/content/docs/guides/api-keys-and-providers.md
+++ b/docs/src/content/docs/guides/api-keys-and-providers.md
@@ -28,7 +28,7 @@ const session = await client.connect({
 });
 ```
 
-If the matching env var for your chosen provider isn't set, `connect()` or the first `ask()` throws. See [Error Handling](/megasthenes/guides/error-handling/) to classify by `errorType`.
+If the matching env var for your chosen provider isn't set, `connect()` or the first `ask()` throws. See [Handling Errors](/megasthenes/guides/error-handling/) to classify by `errorType`.
 
 ### Per-ask override
 

--- a/docs/src/content/docs/guides/configuration.md
+++ b/docs/src/content/docs/guides/configuration.md
@@ -254,16 +254,27 @@ const sdk = new NodeSDK({ traceExporter: new ConsoleSpanExporter() });
 sdk.start();
 ```
 
-#### Langfuse
+#### Integrating with an observability platform
+
+Most LLM observability platforms (Arize Phoenix, Langfuse, Honeycomb, Jaeger) accept OTLP, so any OTLP exporter will work. The example below ships traces to a local [Arize Phoenix](https://phoenix.arize.com/) instance:
 
 ```ts
 import { NodeSDK } from "@opentelemetry/sdk-node";
-import { LangfuseSpanProcessor } from "@langfuse/otel";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
+import { BatchSpanProcessor } from "@opentelemetry/sdk-trace-base";
 
 const sdk = new NodeSDK({
-  spanProcessors: [new LangfuseSpanProcessor()],
+  spanProcessors: [
+    new BatchSpanProcessor(
+      new OTLPTraceExporter({
+        url: "http://localhost:6006/v1/traces",
+      }),
+    ),
+  ],
 });
 sdk.start();
 ```
+
+Phoenix reads the [OpenInference](https://github.com/Arize-ai/openinference) semantic conventions, while megasthenes emits OTel GenAI spans. Traces will arrive with the basic export above, but Phoenix's built-in token-count, cost, and input/output panels stay empty until you map between the two. See [`scripts/ask-with-phoenix.ts`](https://github.com/nilenso/megasthenes/blob/main/scripts/ask-with-phoenix.ts) for a worked `SpanProcessor` that enriches spans with the OpenInference attributes Phoenix expects.
 
 See the [Observability guide](/megasthenes/guides/observability/) for the full span hierarchy, emitted attributes/events, and structured error tracing.

--- a/docs/src/content/docs/guides/error-handling.md
+++ b/docs/src/content/docs/guides/error-handling.md
@@ -1,5 +1,5 @@
 ---
-title: Error Handling
+title: Handling Errors
 description: Handle structured errors from stream events and thrown exceptions.
 sidebar:
   order: 5
@@ -12,7 +12,7 @@ megasthenes surfaces errors in two ways:
 
 Both carry a typed `errorType` field for programmatic handling.
 
-### ErrorType
+### Error Types
 
 All errors include one of these types:
 

--- a/docs/src/content/docs/guides/handling-responses.md
+++ b/docs/src/content/docs/guides/handling-responses.md
@@ -81,7 +81,7 @@ const result = await stream.result();
 |---|---|
 | `iteration_start` | Marks the start of each LLM inference iteration (zero-based `index`). |
 | `compaction` | Context was compacted. Carries `summary`, `tokensBefore`, `tokensAfter`. |
-| `error` | Unrecoverable error during the turn. See [Error Handling](/megasthenes/guides/error-handling/). |
+| `error` | Unrecoverable error during the turn. See [Handling Errors](/megasthenes/guides/error-handling/). |
 
 ### TurnResult Structure
 

--- a/docs/src/content/docs/guides/observability.md
+++ b/docs/src/content/docs/guides/observability.md
@@ -5,13 +5,13 @@ sidebar:
   order: 7
 ---
 
-megasthenes instruments session setup and turns with [OpenTelemetry](https://opentelemetry.io/) spans using the [GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/), plus a small set of `megasthenes.*` attributes for repository- and agent-specific details.
+megasthenes instruments session setup and turns with [OpenTelemetry](https://opentelemetry.io/) spans, following the [GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/) and adding a small set of `megasthenes.*` attributes for repository- and agent-specific details.
 
-The library depends only on `@opentelemetry/api`. If your application does not install and register an OTel SDK, tracing is a no-op.
+The library depends only on `@opentelemetry/api`. Without a registered OTel SDK, tracing is a no-op.
 
 ## Setup
 
-Install the OpenTelemetry SDK and configure a tracer provider **before** creating any sessions:
+Register an OTel tracer provider **before** creating any sessions:
 
 ```ts
 import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
@@ -23,11 +23,9 @@ provider.addSpanProcessor(new SimpleSpanProcessor(new OTLPTraceExporter()));
 provider.register();
 ```
 
-Once registered, `client.connect(...)` and later `session.ask()` calls automatically emit spans.
+`client.connect(...)` and `session.ask()` calls will then automatically emit spans.
 
 ## Trace structure
-
-A traced session currently looks like this:
 
 ```text
 ask
@@ -43,182 +41,82 @@ ask
 └── ask.turn
 ```
 
-- `ask`: long-lived root span for one connected session
-- `connect`: repository setup for that session
-- `repo.clone_or_fetch`: local bare clone / fetch / cache reuse
-- `repo.resolve_commitish`: commit resolution via `git rev-parse`
-- `repo.create_worktree`: worktree creation or reuse
-- `ask.turn`: one span per `session.ask()` call
-- `compaction`: emitted once per turn, even if no compaction happens
-- `gen_ai.chat`: one span per LLM iteration
-- `gen_ai.execute_tool`: one span per tool execution
+- `ask` — long-lived root span for one connected session
+- `connect` — repository setup
+- `repo.clone_or_fetch` — local bare clone, fetch, or cache reuse
+- `repo.resolve_commitish` — `git rev-parse` for the requested commitish
+- `repo.create_worktree` — worktree reuse or `git worktree add`
+- `ask.turn` — one per `session.ask()` call
+- `compaction` — emitted once per turn, even when compaction is skipped
+- `gen_ai.chat` — one per LLM iteration
+- `gen_ai.execute_tool` — one per tool execution
 
-## Span reference
+## Span attributes
+
+The `connect` and `repo.*` spans carry only standard span metadata. The spans below add more.
 
 ### `ask`
 
-Long-lived root span for a connected session.
-
-**Always includes**
-- `megasthenes.repo.url`
-- `megasthenes.repo.requested_commitish`
-- `megasthenes.connect.mode`
-- `megasthenes.session.id` once the session has been created
-- `megasthenes.repo.commitish` once the repo has been resolved
-
-Use this span for end-to-end session duration and to correlate setup and later turns in one trace.
-
-### `connect`
-
-Child span for repository setup during `client.connect(...)`.
-
-This span is where local clone/fetch/worktree work or sandbox clone work is recorded.
-
-### `repo.clone_or_fetch`
-
-Local child span covering:
-- cache hit / cache reuse
-- `git fetch` when the requested commitish is missing locally
-- fresh `git clone --bare`
-
-### `repo.resolve_commitish`
-
-Local child span covering `git rev-parse` for the requested commitish.
-
-### `repo.create_worktree`
-
-Local child span covering worktree reuse or `git worktree add`.
+- `megasthenes.repo.url`, `megasthenes.repo.requested_commitish`, `megasthenes.connect.mode`
+- `megasthenes.session.id` once the session is created
+- `megasthenes.repo.commitish` once the repo is resolved
 
 ### `ask.turn`
 
-Child span for a single `session.ask()` call.
+Attributes: `gen_ai.operation.name = "chat"`, `gen_ai.request.model`, `megasthenes.session.id`, `megasthenes.repo.url`, `megasthenes.repo.commitish`. On successful completion, also `gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`, `megasthenes.total_iterations`, `megasthenes.total_tool_calls`.
 
-**Always includes**
-- `gen_ai.operation.name = "chat"`
-- `gen_ai.request.model`
-- `megasthenes.session.id`
-- `megasthenes.repo.url`
-- `megasthenes.repo.commitish`
-
-**Events**
-- `gen_ai.system_instructions`
-- `gen_ai.input.messages`
-
-**On successful completion**
-- `gen_ai.usage.input_tokens`
-- `gen_ai.usage.output_tokens`
-- `megasthenes.total_iterations`
-- `megasthenes.total_tool_calls`
-
-Use this span for turn-level latency, token totals, iteration counts, and overall success/failure.
+Events: `gen_ai.system_instructions`, `gen_ai.input.messages`.
 
 ### `compaction`
 
-Child span covering context compaction before the turn's first generation call.
-
-**Attributes**
-- `megasthenes.compaction.was_compacted`
-- `megasthenes.compaction.tokens_before` when compaction happens
-- `megasthenes.compaction.tokens_after` when compaction happens
-
-This span is emitted even when compaction is skipped, so you can measure how often compaction is considered vs. actually triggered.
+`megasthenes.compaction.was_compacted`. When compaction actually runs, also `megasthenes.compaction.tokens_before` and `megasthenes.compaction.tokens_after`.
 
 ### `gen_ai.chat`
 
-Child span for one LLM inference iteration.
+Attributes: `gen_ai.operation.name = "chat"`, `gen_ai.request.model`, `gen_ai.provider.name`, `megasthenes.iteration`, `gen_ai.response.finish_reason` (when available), `gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`, `gen_ai.usage.cache_read.input_tokens`, `gen_ai.usage.cache_creation.input_tokens`.
 
-**Attributes**
-- `gen_ai.operation.name = "chat"`
-- `gen_ai.request.model`
-- `gen_ai.provider.name`
-- `megasthenes.iteration`
-- `gen_ai.response.finish_reason` when available
-- `gen_ai.usage.input_tokens`
-- `gen_ai.usage.output_tokens`
-- `gen_ai.usage.cache_read.input_tokens`
-- `gen_ai.usage.cache_creation.input_tokens`
-
-**Events**
-- `gen_ai.input.messages`
-- `gen_ai.output.messages`
-
-Use these spans to inspect per-iteration prompts, responses, stop reasons, and token usage.
+Events: `gen_ai.input.messages`, `gen_ai.output.messages`.
 
 ### `gen_ai.execute_tool`
 
-Child span for one tool invocation made by the model.
+Attributes: `gen_ai.operation.name = "execute_tool"`, `gen_ai.tool.name`, `gen_ai.tool.call.id`.
 
-**Attributes**
-- `gen_ai.operation.name = "execute_tool"`
-- `gen_ai.tool.name`
-- `gen_ai.tool.call.id`
+Events: `gen_ai.tool.call.arguments`, `gen_ai.tool.call.result`.
 
-**Events**
-- `gen_ai.tool.call.arguments`
-- `gen_ai.tool.call.result`
+## Errors
 
-Use these spans to measure tool latency and inspect tool arguments/results.
+When a span fails, megasthenes sets `error.type`, `megasthenes.error.stage` (one of `ask`, `connect`, `generation`, `compaction`, `tool_execution`), `megasthenes.error.name`, and `megasthenes.error.message`. `error.type` aligns with the SDK's public `ErrorType` values so traces and programmatic errors share one vocabulary.
 
-## Error spans
+### `error.type` values
 
-When a span fails, megasthenes records both standard span status and structured error attributes.
-
-**Common error attributes**
-- `error.type`
-- `megasthenes.error.stage`
-- `megasthenes.error.name`
-- `megasthenes.error.message`
-
-**Stages**
-- `ask`
-- `connect`
-- `generation`
-- `compaction`
-- `tool_execution`
-
-`error.type` is aligned with the public API's `ErrorType` values where applicable, so trace queries and programmatic SDK errors use the same vocabulary.
-
-### Error types you may see
-
-| `error.type` | Meaning |
+| Value | Meaning |
 |---|---|
-| `aborted` | The turn was aborted after tracing had started |
-| `max_iterations` | The turn exhausted its tool-use / generation loop budget |
-| `context_overflow` | The provider rejected the prompt because it exceeded the context window |
-| `provider_error` | The provider returned a non-specific API error |
-| `empty_response` | The model returned no final text content |
-| `network_error` | A thrown network-level failure occurred during generation |
-| `internal_error` | megasthenes hit an internal failure, or a tool/compaction span failed |
+| `aborted` | Turn was aborted after tracing had started |
+| `max_iterations` | Turn exhausted its tool-use / generation loop budget |
+| `context_overflow` | Provider rejected the prompt for exceeding the context window |
+| `provider_error` | Provider returned a non-specific API error |
+| `empty_response` | Model returned no final text content |
+| `network_error` | Network-level failure during generation |
+| `internal_error` | Internal failure, or a tool/compaction span failed |
 
-### Typical error shapes
+### Typical shapes
 
-**Provider failure**
-- `gen_ai.chat`: `error.type = provider_error`, `megasthenes.error.stage = generation`
-- `ask`: `error.type = provider_error`, `megasthenes.error.stage = ask`
+Generation failures originate on `gen_ai.chat` and propagate to the root `ask`. Tool and compaction failures stay local — the turn may still finish successfully.
 
-**Context overflow**
-- `gen_ai.chat`: `error.type = context_overflow`
-- `ask`: `error.type = context_overflow`
+| Failure | Failing span(s) | `error.type` | `megasthenes.error.stage` |
+|---|---|---|---|
+| Provider failure | `gen_ai.chat` → `ask` | `provider_error` | `generation` on `gen_ai.chat`; `ask` on the root |
+| Context overflow | `gen_ai.chat` → `ask` | `context_overflow` | not set |
+| Network failure | `gen_ai.chat` → `ask` | `network_error` | not set |
+| Empty final response | `gen_ai.chat` → `ask` | `empty_response` | not set |
+| Tool failure | `gen_ai.execute_tool` only | `internal_error` | `tool_execution` |
+| Compaction failure | `compaction` only | `internal_error` | `compaction` |
 
-**Network failure**
-- `gen_ai.chat`: `error.type = network_error`
-- `ask`: `error.type = network_error`
+After a failed tool call the model can observe the error and keep going; a failed compaction leaves the turn running on uncompacted context.
 
-**Empty final response**
-- `gen_ai.chat`: `error.type = empty_response`
-- `ask`: `error.type = empty_response`
+### Example trace shapes
 
-**Tool failure that the model recovers from**
-- `gen_ai.execute_tool`: `error.type = internal_error`, `megasthenes.error.stage = tool_execution`
-- later `ask` / `gen_ai.chat` spans may still finish successfully if the model continues
-
-**Compaction failure**
-- `compaction`: `error.type = internal_error`, `megasthenes.error.stage = compaction`
-- the turn may still continue successfully
-
-## Example failing trace
-
-A provider failure in one turn typically looks like:
+Provider failure:
 
 ```text
 ask [OK]
@@ -228,7 +126,7 @@ ask [OK]
     └── gen_ai.chat [ERROR]
 ```
 
-A tool failure that the model recovers from may look like:
+Tool failure that the model recovers from:
 
 ```text
 ask [OK]
@@ -240,19 +138,7 @@ ask [OK]
     └── gen_ai.chat [OK]
 ```
 
-## What is currently traced
+## Limitations
 
-Today, tracing covers the connected session lifecycle:
-- root `ask` session span
-- `connect`
-- local clone/fetch/rev-parse/worktree spans
-- per-turn `ask.turn`
-- compaction
-- per-iteration generation
-- per-tool execution
-
-## Current limitations
-
-The following flows still have gaps:
-- sandbox clone tracing is present, but other sandbox lifecycle operations are still less detailed than local git setup
-- a turn aborted before its `ask.turn` span starts will not produce a turn span, though the session root span still exists
+- Sandbox clone tracing exists, but other sandbox lifecycle operations are less detailed than local git setup.
+- A turn aborted before its `ask.turn` span starts won't produce a turn span, though the session root span still exists.

--- a/docs/src/content/docs/guides/sandbox.md
+++ b/docs/src/content/docs/guides/sandbox.md
@@ -101,8 +101,9 @@ Verify the sandbox is running:
 
 ```bash
 curl http://localhost:8080/health
-# Expected: {"ok":true}
 ```
+
+You should see `{"ok":true}` in the response.
 
 ### Authentication
 

--- a/docs/src/content/docs/start-here/getting-started.md
+++ b/docs/src/content/docs/start-here/getting-started.md
@@ -7,6 +7,12 @@ sidebar:
 
 megasthenes is a TypeScript library that lets you programmatically ask questions to any GitHub or GitLab repository. It connects an LLM to a cloned repo with tools for code search, file reading, and git operations, then returns structured answers with source references.
 
+> **Why "Megasthenes"?**
+>
+> Megasthenes was a Greek ambassador sent to the Maurya court around 300 BCE. He spent years in an unfamiliar land, observed carefully, and wrote *Indica* — one of the first detailed accounts of the Indian subcontinent by an outsider. Not a tourist's diary, but a structured report: governance, geography, trade routes, how things actually worked.
+>
+> This library does something similar with codebases. You drop it into a repository it has never seen, and it pokes around — reads files, greps for patterns, walks the git history — until it can give you a coherent, sourced answer about what's in there.
+
 ## Features
 
 - **Ask questions about any repository** — Point it at any public or private repository URL and start asking questions in plain language.
@@ -53,15 +59,20 @@ sudo pacman -S --noconfirm git ripgrep fd
 ```ts
 import { Client } from "@nilenso/megasthenes";
 
+// Initialise a new client
 const client = new Client();
+
+// Connect to a public repository
 const session = await client.connect({
   repo: { url: "https://github.com/owner/repo" },
   model: { provider: "openrouter", id: "anthropic/claude-sonnet-4-6" },
   maxIterations: 20,
 });
 
-// Stream events as they arrive
+// Ask a question
 const stream = session.ask("What does this repo do?");
+
+// Stream events as they arrive
 for await (const event of stream) {
   if (event.type === "text_delta") process.stdout.write(event.delta);
 }
@@ -71,5 +82,6 @@ const result = await session.ask("How are the tests structured?").result();
 console.log(result.steps);   // All steps: text, tool calls, thinking, etc.
 console.log(result.usage);   // Token usage across all iterations
 
+// Finally, close the session
 await session.close();
 ```

--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -129,3 +129,20 @@
 .site-title > span {
 	display: none;
 }
+
+/* Shell prompt prefix rendered via ::before so the prompt isn't part of
+   textContent — Expressive Code's copy button skips it, and manual
+   selection can't grab it either. The :has(> *) guard excludes empty
+   source lines (which contain only a "\n" text node). The
+   .is-shell-comment class is added by the shell-comment-marker EC plugin
+   to lines whose source starts with "#", so comments render un-prompted. */
+pre[data-language="bash"] .ec-line:not(.is-shell-comment) > .code:has(> *)::before,
+pre[data-language="sh"] .ec-line:not(.is-shell-comment) > .code:has(> *)::before,
+pre[data-language="shell"] .ec-line:not(.is-shell-comment) > .code:has(> *)::before,
+pre[data-language="shellsession"] .ec-line:not(.is-shell-comment) > .code:has(> *)::before,
+pre[data-language="zsh"] .ec-line:not(.is-shell-comment) > .code:has(> *)::before {
+	content: "$ ";
+	color: var(--sl-color-gray-3);
+	user-select: none;
+	-webkit-user-select: none;
+}


### PR DESCRIPTION
## Summary
- **Shell prompts in code blocks** — a CSS `::before` rule injects `$ ` on command lines in `bash`/`sh`/`shell`/`shellsession`/`zsh` blocks. Because `::before` content lives outside `textContent`, Expressive Code's copy button and manual selection both skip it, so the prompt is visible but never copied. A small Expressive Code plugin (`docs/ec-plugins/shell-comment-marker.mjs`) tags lines whose source starts with `#` as `.is-shell-comment`, which the CSS selector excludes — so `# Download ...` style comments render un-prompted.
- **Observability guide refresh** — dropped the redundant "What is currently traced" section (pure duplication of the trace-structure tree), trimmed per-span intro/closer prose that said nothing beyond what the tree legend already carried, and folded the six-bullet "typical error shapes" block into a single table that makes the `gen_ai.chat` → `ask` propagation pattern explicit.
- **Configuration guide** — the Langfuse tracing block is now "Integrating with an observability platform" with an Arize Phoenix example, plus a pointer to `scripts/ask-with-phoenix.ts` for the GenAI-to-OpenInference enrichment layer (Phoenix's per-span token/cost/IO panels need that mapping to populate).
- **Renames** — `Error Handling` guide → `Handling Errors`, its `ErrorType` section heading → `Error Types`. URL slug unchanged so no broken links; cross-references in `handling-responses.md` and `api-keys-and-providers.md` updated to match.
- **Sandbox guide** — moved `# Expected: {"ok":true}` out of its bash block into prose so it doesn't render as `$ # Expected: ...` under the new prompt rule.

## Test plan
- [ ] `bun --cwd docs dev` — verify shell blocks render with a muted `$ ` prefix and comment lines render without it
- [ ] Click the copy button on a shell block and paste into a terminal — the `$ ` should not be present
- [ ] Verify the Observability page still reads coherently top-to-bottom after the rewrite
- [ ] Verify the "Handling Errors" title appears in the sidebar and cross-reference links still land on the right page
- [ ] Verify the Configuration guide's Phoenix example renders correctly and the link to `scripts/ask-with-phoenix.ts` points to the right file

🤖 Generated with [Claude Code](https://claude.com/claude-code)