### PR TITLE
chore(release): bump version to 0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ npx jsr add @nilenso/megasthenes
 
 For Docker or manual setup, add to `package.json`:
 ```json
-"@nilenso/megasthenes": "npm:@jsr/nilenso__megasthenes@0.0.19"
+"@nilenso/megasthenes": "npm:@jsr/nilenso__megasthenes@0.1.0"
 ```
 
 And create `.npmrc`:

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nilenso/megasthenes",
-	"version": "0.0.19",
+	"version": "0.1.0",
 	"license": "MIT",
 	"exports": {
 		".": "./src/index.ts"


### PR DESCRIPTION
## Summary
- Bump `jsr.json` version from `0.0.19` → `0.1.0`
- Update README install snippet to reference `0.1.0`

## Context
The `v0.1.0` tag was pushed earlier today while `jsr.json` still read `0.0.19`. The CI `publish` job ran but JSR skipped it (`Warning: Skipping, already published @nilenso/megasthenes@0.0.19`), so nothing actually went out under `0.1.0`.

After this merges, the stale `v0.1.0` tag + GitHub Release will be deleted and re-created against the merge commit so that CI publishes a real `0.1.0` to JSR.

## Test plan
- [ ] CI green on this branch
- [ ] After merge + re-tag: confirm JSR publish job succeeds (no `Skipping, already published` warning)
- [ ] Verify https://jsr.io/@nilenso/megasthenes shows `0.1.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)