### PR TITLE
chore: remove dead postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
 		"lint": "biome lint .",
 		"check": "biome check --write .",
 		"test": "bun test",
-		"web": "bun run web/server.ts",
-		"postinstall": "patch -p0 -N -d node_modules/@mariozechner/pi-ai < patches/pi-ai-output-config.patch || true"
+		"web": "bun run web/server.ts"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.4.12",


### PR DESCRIPTION
## Summary

The `postinstall` script in `package.json` references `patches/pi-ai-output-config.patch`, but that patch file was never committed to the repo. The trailing `|| true` made it silently no-op on every `bun install`.

The line was added in commit 9f2cf09 (`feat: add configurable adaptive thinking support`), but the `patches/` directory and the `.patch` file itself were not part of that commit (verified via `git show 9f2cf09 --name-status` — only modified files, no additions). The currently installed `@mariozechner/pi-ai@0.62.0` already supports `output_config` natively in its Anthropic provider, so even if the patch's intent could be reconstructed, it wouldn't be needed.

Removing the dead line.

## Test plan

- [x] `bun install` completes cleanly with no errors or warnings
- [x] `bun test` passes
- [x] Adaptive thinking still works end-to-end (no regression — the patch was a no-op anyway)

🤖 Generated with [Claude Code](https://claude.com/claude-code)